### PR TITLE
[#30] 사업자번호 인풋 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,8 @@
 		"@typescript-eslint/strict-boolean-expressions": "off",
 		"@typescript-eslint/restrict-plus-operands": "off",	// 빈 데이터에 대한 "+=" 연산자를 방지하는 룰  
 		"@typescript-eslint/restrict-template-expressions": "off",	// any 타입 데이터를 literal template 에 사용하려고 하면 발동하는 룰
+		"@typescript-eslint/naming-convention": "off",	// 외부 API Response 는 Naming Convention 이 다를 수 있음
+		 "@typescript-eslint/no-misused-promises": ["error", { "checksVoidReturn": { "attributes": false }}],
 		"no-useless-return": "off",
 		"react/react-in-jsx-scope": "off",
 		"no-var": "error",

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# local env files
+# env files
 .env*.local
+.env
+.env.development
+.env.production
 
 # vercel
 .vercel

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -1,7 +1,28 @@
 'use client';
 
-import { TextField, PostcodePopupOpenBtn } from 'components/feature';
-import { useState } from 'react';
+import { RefObject, useState, useRef } from 'react';
+import axios from 'axios';
+import { LargeBtn } from 'components/shared';
+import { TextField, PostcodePopupOpenBtn, BusinessLicenseTextField } from 'components/feature';
+import { extractBusinessLicenseExceptHyhpen } from 'core/storeRegistrationService';
+import style from 'styles/style';
+
+interface IBusinessLicenseStatusResponse {
+	match_cnt: number;
+	request_cnt: number;
+	status_code: string;
+	data: Array<{
+		b_no: string;
+		b_stt: '01' | '02' | '03';
+		b_stt_cd: '01' | '02' | '03';
+		tax_type: string;
+		tax_type_cd: '1' | '2' | '3' | '4' | '5' | '6' | '7';
+		end_dt: string;
+		utcc_yn: 'Y' | 'N';
+		tax_type_change_dt: string;
+		invoice_apply_at: string;
+	}>;
+}
 
 const Step2 = () => {
 	const [storePostcodeInputs, setStorePostcodeInputs] = useState({
@@ -25,6 +46,37 @@ const Step2 = () => {
 			...storePostcodeInputs,
 			addressDetail: event.target.value,
 		});
+	};
+
+	const businessLicenseInputRef = useRef() as RefObject<HTMLInputElement>;
+	const [businessLicenseStatus, setBusinessLicenseStatus] = useState<'normal' | 'success' | 'error'>('normal');
+
+	const handleBusinessLicenseStatusCheck = async () => {
+		if (!businessLicenseInputRef.current) return;
+
+		const businessLicenseStatusResponse = await axios.post<IBusinessLicenseStatusResponse>(
+			`${process.env.NEXT_PUBLIC_NTS_API_BASE_URL}/status${
+				process.env.NEXT_PUBLIC_NTS_API_KEY && `?serviceKey=${process.env.NEXT_PUBLIC_NTS_API_KEY}`
+			}`,
+			{
+				b_no: [extractBusinessLicenseExceptHyhpen(businessLicenseInputRef.current?.value)],
+			},
+		);
+
+		const { b_stt_cd } = businessLicenseStatusResponse.data.data[0];
+
+		if (b_stt_cd === '01') {
+			// 활성사업자
+			setBusinessLicenseStatus('success');
+		}
+
+		if (b_stt_cd === '02') {
+			// 휴업자
+		}
+
+		if (b_stt_cd === '03') {
+			// 폐업자
+		}
 	};
 
 	return (
@@ -54,6 +106,16 @@ const Step2 = () => {
 				width={{ width: '560px' }}
 				onChange={handleStoreAddressDetailChange}
 			/>
+
+			<BusinessLicenseTextField
+				businessLicenseTextFieldRef={businessLicenseInputRef}
+				name="businessLicense"
+				inputFlag={businessLicenseStatus}
+			/>
+
+			<LargeBtn style={style.btnStyle.white_btn} onClick={handleBusinessLicenseStatusCheck}>
+				번호 조회
+			</LargeBtn>
 		</>
 	);
 };

--- a/components/feature/BusinessLicenseTextField/index.tsx
+++ b/components/feature/BusinessLicenseTextField/index.tsx
@@ -1,21 +1,17 @@
-import { ChangeEvent, KeyboardEvent, useState } from 'react';
-import style from 'styles/style';
+import { ChangeEvent, KeyboardEvent, RefObject, useState } from 'react';
 import * as S from '../TextField/styled';
-// 다른 TextField와는 다르게 입력값 처리할 예정
-// 이유 1: 입력할 때 하이픈을 넣어줘야 함
-// 이유2: 하이픈 넣어준 것 제외한 값을 서버에 넘겨야 함
+import style from 'styles/style';
+
 type Props = {
+	inputFlag: 'normal' | 'success' | 'error';
+	businessLicenseTextFieldRef: RefObject<HTMLInputElement>;
 	name: string;
-	flag: string; // normal , success , error
-};
-const BusinessLicenseTextField = ({ name, ...props }: Props) => {
-	const [flag, setFlag] = useState<string>(props.flag);
+} & React.InputHTMLAttributes<HTMLInputElement>;
+
+const BusinessLicenseTextField = ({ businessLicenseTextFieldRef, name, inputFlag, ...props }: Props) => {
 	const [businessLicense, setBusinessLicense] = useState<string>('');
 	const [currentKey, setCurrentKey] = useState<string>('');
-	const handleError = () => {
-		if (flag === 'normal') return;
-		setFlag('normal');
-	};
+
 	const handleBusinessLicense = (e: ChangeEvent<HTMLInputElement>) => {
 		// 나중에 한 번 더 체크
 		let newText = e.target.value;
@@ -31,25 +27,28 @@ const BusinessLicenseTextField = ({ name, ...props }: Props) => {
 		}
 		setBusinessLicense(newText.replace(/(\d{3})(\d{2})(\d{5})/, '$1-$2-$3'));
 	};
+
 	const checkKey = (e: KeyboardEvent<HTMLInputElement>) => {
 		setCurrentKey(() => e.key);
 	};
+
 	return (
 		<S.TextFieldContainer>
 			<S.StyledTextFiled
-				onFocus={handleError}
-				name={name}
-				flag={flag}
-				style={style.textFieldWidth.textField_width_003}
-				placeholder="입력해주세요"
+				style={style.textFieldWidth.textField_width_123}
+				flag={inputFlag}
+				ref={businessLicenseTextFieldRef}
 				type="search"
+				placeholder="입력해주세요"
+				name={name}
 				value={businessLicense}
+				disabled={inputFlag === 'success'}
 				onChange={handleBusinessLicense}
 				onKeyDown={checkKey}
-				disabled={flag === 'success'}
 			/>
-			{flag === 'error' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
-			{flag === 'success' && <S.SuccessMessage>✓ 입점가능한 사업자 번호입니다.</S.SuccessMessage>}
+
+			{inputFlag === 'error' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
+			{inputFlag === 'success' && <S.SuccessMessage>✓ 입점가능한 사업자 번호입니다.</S.SuccessMessage>}
 		</S.TextFieldContainer>
 	);
 };

--- a/core/storeRegistrationService.ts
+++ b/core/storeRegistrationService.ts
@@ -1,0 +1,6 @@
+export const extractBusinessLicenseExceptHyhpen = (businessLicense: string) => {
+	return businessLicense
+		.split('')
+		.filter((c) => c !== '-')
+		.join('');
+};


### PR DESCRIPTION
## 📎 Related Issues

- #30 

<br />

## 📋 작업 내용

- [x] 사업자번호조회 API 를 연동시킨다.
- [x] API 를 통해 사업자번호 유효성 결과를 획득한다.
- [x] 유효성 결과에 대한 UI 변화를 표현한다.

<br />

## 🔎 PR Point

### 사업자등록조회 API 사용에 있어

- 무료 사업자등록정보 조회 API 를 사용하므로, 하루 최대 API Call 제한 횟수(`100회`)가 있으므로, 실제 사용할 때 이 점을 유의해서 사용할 것
- 현재는 우리에게 필요한 정보가 `사용자가 입력한 사업자번호` -> `사업중인지 유무` 임
  - API 를 연결하면서 그 외 무료 API 에서도 확인할 수 있는 괜찮은 정보들이 상당히 많다는 것을 알게 됨
  - 예를 들어, `계속사업자(=사업중)` 뿐만 아니라, `폐업중`, `휴업중` 같은 정보 등등
  - 따라서 이후에 이러한 정보도 잘 활용하면 좀 더 다양한 입점 단계에서 확인 가능한 프로세스를 추가할 수 있다거나, 사업자등록정보 조회 결과에 따른 Pump 입점신청 프로세스 입력 프로세스에 대한 핸들링이 가능하다고 생각함, 참고할 것

### 프로젝트 내 API 시스템에 대해

- 이번 PR 에 대한 기능 구현을 하면서, 외부 API 요청이 필요했기 때문에 처음으로 API 로직이 추가되었음
- 빅터의 메인 작업이 아니어서, API 로 데이터를 잘 가져오는지 확인하는 것이 최우선이었으므로, 프로젝트 내 HTTP Client 시스템을 구축 안하고 axios 라이브러를 바로 가져와서 사용하는 방식으로 적용함 -> 결코 이상적인 방식이 아님, 보완해야함, 참고할 것
 
### `BusinessLicenseTextField` 컴포넌트 Props 의 변경

- 이 중, 특히 `flag` props 에 대한 존재가 구현을 하면서 애매하다고 생각함
- 빅터가 파악한 `flag` 의 목적이, 사업자등록번호 유효성에 따른 `BusinessLicenseTextField` 내부에서 Message 를 표현하기 위함이고, BusinessLicenseTextField 컴포넌트 렌더링 초기부분에, 내부적으로 `flag` 라는 useState 를 통해 생성한 상태값이 존재해서, 이 둘의 관계가 애매하다고 생각하고, 실제로 기능 구현 중에 상태값에 따른 변화에 대해 싱크가 맞지 않는 문제가 있어서, 과감하게 내부 flag 상태값은 제거, 외부에서 inputFlag 정보를 통해서 BusinessLicenseTextField 에서는 Message 에 대한 상태를 핸들링하기로 함 


<br />

## 😡 Trouble Shooting

- (이 작업을 하던 중에 발생했던 것)

<br />

## 👀 스크린샷 / GIF / 링크

![business_number_confirm](https://user-images.githubusercontent.com/50790145/212521756-42685f82-7954-4cdb-ba6f-68a5a97f14d0.gif)


<br />

## ➕ 추가적인 태스크

- [ ] 레이아웃 배치 잘해서 사용하기 

<br />

## 📚 Reference

- [Pump Notion - 사업자등록번호 유효성 조회 구현 NOTE (Writer. 빅터), 접근안된다면 말할 것](https://www.notion.so/yapp-workspace/API-c3483c8bc1c1458e941d832c068de9a5) 

<br />

## ✅ PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다. (개인 작업시에만 확인)
- [x] Critical 한 Error 또는 Warning 이 존재하지 않습니다. 
- [x] 브라우저에 console 이 존재하지 않습니다.
