### PR TITLE
[#34] step1, step2 form onSubmit 로직 구현

### DIFF
--- a/app/registration/step1/page.tsx
+++ b/app/registration/step1/page.tsx
@@ -7,19 +7,21 @@ import { theme } from 'styles';
 import style from 'styles/style';
 
 const Step1 = () => {
+	const { inputArr, changeError, changeNormal } = useStep1Store();
+
 	const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		const step1Inputs = e.target.step1;
 	};
+	const handleCheckError = (inputArr: object[]) => {};
 	return (
-		<form onSubmit={(e) => handleOnSubmit}>
+		<form onSubmit={handleOnSubmit}>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="managerName">
 					<Typography variant="h2" aggressive="body_oneline_004" color={theme.colors.gray_005}>
 						대표자명
 					</Typography>
 				</label>
-				<TextField id="managerName" name="step1" flag="normal" width="320px" />
+				<TextField id="managerName" name="step1" inputFlag="normal" width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="managerEmail">
@@ -27,7 +29,7 @@ const Step1 = () => {
 						이메일
 					</Typography>
 				</label>
-				<TextField id="managerEmail" name="step1" flag="normal" width="320px" />
+				<TextField id="managerEmail" name="step1" inputFlag="normal" width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="managerPhonenumber">
@@ -35,7 +37,7 @@ const Step1 = () => {
 						전화번호
 					</Typography>
 				</label>
-				<TextField id="managerPhonenumber" name="step1" flag="normal" width="320px" />
+				<TextField id="managerPhonenumber" name="step1" inputFlag="normal" width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.FlexBox justifyContent="center" style={{ paddingTop: '16px' }}>
 				<LargeBtn style={style.btnStyle.primary_btn_002} type="submit">
@@ -47,3 +49,6 @@ const Step1 = () => {
 };
 
 export default Step1;
+function useStep1Store() {
+	throw new Error('Function not implemented.');
+}

--- a/app/registration/step1/page.tsx
+++ b/app/registration/step1/page.tsx
@@ -2,6 +2,7 @@
 
 import { TextField } from 'components/feature';
 import { LargeBtn, StyledLayout, Typography } from 'components/shared';
+import { checkEmptyInputError } from 'core/storeRegistrationService';
 import { FormEvent } from 'react';
 import { useStep1Store } from 'store/actions/storeRegistrationStore';
 import { theme } from 'styles';
@@ -9,15 +10,11 @@ import style from 'styles/style';
 
 const Step1 = () => {
 	const { inputArr, changeError, changeNormal } = useStep1Store();
-
 	const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		handleCheckError(e.target.step1);
-	};
-	const handleCheckError = (inputArr: RadioNodeList) => {
-		for (let i = 0; i < inputArr.length; i++) {
-			if (inputArr[i].value === '') changeError(i);
-		}
+		const emptyInput = checkEmptyInputError(e.currentTarget.step1, changeError);
+		if (emptyInput !== 0) return;
+		// 여기서부터 서버 api 연결 로직
 	};
 
 	return (

--- a/app/registration/step1/page.tsx
+++ b/app/registration/step1/page.tsx
@@ -3,6 +3,7 @@
 import { TextField } from 'components/feature';
 import { LargeBtn, StyledLayout, Typography } from 'components/shared';
 import { FormEvent } from 'react';
+import { useStep1Store } from 'store/actions/storeRegistrationStore';
 import { theme } from 'styles';
 import style from 'styles/style';
 
@@ -11,8 +12,14 @@ const Step1 = () => {
 
 	const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
+		handleCheckError(e.target.step1);
 	};
-	const handleCheckError = (inputArr: object[]) => {};
+	const handleCheckError = (inputArr: RadioNodeList) => {
+		for (let i = 0; i < inputArr.length; i++) {
+			if (inputArr[i].value === '') changeError(i);
+		}
+	};
+
 	return (
 		<form onSubmit={handleOnSubmit}>
 			<StyledLayout.TextFieldSection>
@@ -21,7 +28,7 @@ const Step1 = () => {
 						대표자명
 					</Typography>
 				</label>
-				<TextField id="managerName" name="step1" inputFlag="normal" width="320px" />
+				<TextField id="managerName" name="step1" onFocus={() => changeNormal(0)} inputFlag={inputArr[0]} width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="managerEmail">
@@ -29,7 +36,7 @@ const Step1 = () => {
 						이메일
 					</Typography>
 				</label>
-				<TextField id="managerEmail" name="step1" inputFlag="normal" width="320px" />
+				<TextField id="managerEmail" name="step1" onFocus={() => changeNormal(1)} inputFlag={inputArr[1]} width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="managerPhonenumber">
@@ -37,7 +44,7 @@ const Step1 = () => {
 						전화번호
 					</Typography>
 				</label>
-				<TextField id="managerPhonenumber" name="step1" inputFlag="normal" width="320px" />
+				<TextField id="managerPhonenumber" name="step1" onFocus={() => changeNormal(2)} inputFlag={inputArr[2]} width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.FlexBox justifyContent="center" style={{ paddingTop: '16px' }}>
 				<LargeBtn style={style.btnStyle.primary_btn_002} type="submit">
@@ -49,6 +56,3 @@ const Step1 = () => {
 };
 
 export default Step1;
-function useStep1Store() {
-	throw new Error('Function not implemented.');
-}

--- a/app/registration/step1/page.tsx
+++ b/app/registration/step1/page.tsx
@@ -25,7 +25,14 @@ const Step1 = () => {
 						대표자명
 					</Typography>
 				</label>
-				<TextField id="managerName" name="step1" onFocus={() => changeNormal(0)} inputFlag={inputArr[0]} width="320px" />
+				<TextField
+					id="managerName"
+					name="step1"
+					emptyErrorMessage="대표자명을"
+					onFocus={() => changeNormal(0)}
+					inputFlag={inputArr[0]}
+					width="320px"
+				/>
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="managerEmail">
@@ -33,7 +40,14 @@ const Step1 = () => {
 						이메일
 					</Typography>
 				</label>
-				<TextField id="managerEmail" name="step1" onFocus={() => changeNormal(1)} inputFlag={inputArr[1]} width="320px" />
+				<TextField
+					emptyErrorMessage="이메일을"
+					id="managerEmail"
+					name="step1"
+					onFocus={() => changeNormal(1)}
+					inputFlag={inputArr[1]}
+					width="320px"
+				/>
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="managerPhonenumber">
@@ -41,7 +55,14 @@ const Step1 = () => {
 						전화번호
 					</Typography>
 				</label>
-				<TextField id="managerPhonenumber" name="step1" onFocus={() => changeNormal(2)} inputFlag={inputArr[2]} width="320px" />
+				<TextField
+					emptyErrorMessage="전화번호를"
+					id="managerPhonenumber"
+					name="step1"
+					onFocus={() => changeNormal(2)}
+					inputFlag={inputArr[2]}
+					width="320px"
+				/>
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.FlexBox justifyContent="center" style={{ paddingTop: '16px' }}>
 				<LargeBtn style={style.btnStyle.primary_btn_002} type="submit">

--- a/app/registration/step1/page.tsx
+++ b/app/registration/step1/page.tsx
@@ -9,9 +9,10 @@ import style from 'styles/style';
 const Step1 = () => {
 	const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
+		const step1Inputs = e.target.step1;
 	};
 	return (
-		<form onSubmit={handleOnSubmit}>
+		<form onSubmit={(e) => handleOnSubmit}>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="managerName">
 					<Typography variant="h2" aggressive="body_oneline_004" color={theme.colors.gray_005}>

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -42,13 +42,14 @@ const Step2 = () => {
 		addressDetail: '', // 상세 주소
 	});
 	const businessLicenseInputRef = useRef() as RefObject<HTMLInputElement>;
-	const [businessLicenseStatus, setBusinessLicenseStatus] = useState<'normal' | 'success' | 'error'>('normal');
+	const [businessLicenseStatus, setBusinessLicenseStatus] = useState<'normal' | 'success' | 'error' | 'notClicked'>('normal');
 	const [selectedStoreImageBtn, setSelectedStoreImageBtn] = useState('defaultImage');
 	const [selectedBusinessHourBtn, setSelectedBusinessHourBtn] = useState('weekDaysWeekEnd');
 	const { inputArr, changeError, changeNormal } = useStep2Store();
 	const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 		const emptyInput = checkEmptyInputError(e.currentTarget.step2, changeError);
+		if (e.currentTarget.step2[0].value !== '' && businessLicenseStatus === 'normal') setBusinessLicenseStatus('notClicked');
 		if (emptyInput !== 0) return;
 
 		// 여기서부터 서버 api 연결 로직

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -79,9 +79,10 @@ const Step2 = () => {
 		});
 	};
 	const handleHoverState = () => {
-		if (businessLicenseStatus === 'error') {
+		if (businessLicenseStatus === 'error' || businessLicenseStatus === 'notClicked') {
 			setBusinessLicenseStatus('normal');
 		}
+
 		changeNormal(0);
 	};
 
@@ -134,7 +135,7 @@ const Step2 = () => {
 						isAuthorizedNumber={businessLicenseStatus}
 						onFocus={handleHoverState}
 					/>
-					<StoreResistrationSmallBtn width={{ width: '106px' }} onClick={handleBusinessLicenseStatusCheck}>
+					<StoreResistrationSmallBtn type="button" width={{ width: '106px' }} onClick={handleBusinessLicenseStatusCheck}>
 						번호 조회
 					</StoreResistrationSmallBtn>
 				</StyledLayout.FlexBox>
@@ -300,7 +301,9 @@ const Step2 = () => {
 				</StyledLayout.FlexBox>
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.FlexBox justifyContent="center" style={{ paddingTop: '16px' }}>
-				<LargeBtn style={style.btnStyle.primary_btn_002}>다음단계</LargeBtn>
+				<LargeBtn type="submit" style={style.btnStyle.primary_btn_002}>
+					다음단계
+				</LargeBtn>
 			</StyledLayout.FlexBox>
 		</form>
 	);

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -67,7 +67,7 @@ const Step2 = () => {
 			addressDetail: event.target.value,
 		});
 	};
-	const handleHoverState = async () => {
+	const handleHoverState = () => {
 		if (businessLicenseStatus === 'error') setBusinessLicenseStatus('normal');
 	};
 
@@ -120,7 +120,7 @@ const Step2 = () => {
 						name="step2"
 						id="businessLicense"
 						inputFlag={businessLicenseStatus}
-						onMouseDown={handleHoverState}
+						onFocus={handleHoverState}
 					/>
 					<StoreResistrationSmallBtn width={{ width: '106px' }} onClick={handleBusinessLicenseStatusCheck}>
 						번호 조회
@@ -133,7 +133,7 @@ const Step2 = () => {
 						상호
 					</Typography>
 				</label>
-				<TextField name="step2" id="storeName" flag="normal" width="320px" />
+				<TextField name="step2" id="storeName" inputFlag="normal" width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="storeTelephoneNumber">
@@ -141,7 +141,7 @@ const Step2 = () => {
 						매장 전화번호
 					</Typography>
 				</label>
-				<TextField name="step2" id="storeTelephoneNumber" flag="normal" width="320px" />
+				<TextField name="step2" id="storeTelephoneNumber" inputFlag="normal" width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="store-address-detail">
@@ -152,7 +152,7 @@ const Step2 = () => {
 				<StyledLayout.FlexBox gap="6px">
 					<TextField
 						readOnly={true}
-						flag="normal"
+						inputFlag="normal"
 						name="step2"
 						id="store-postcode"
 						value={storePostcodeInputs.zonecode}
@@ -163,14 +163,14 @@ const Step2 = () => {
 
 				<TextField
 					readOnly={true}
-					flag="normal"
+					inputFlag="normal"
 					name="step2"
 					id="store-address"
 					value={storePostcodeInputs.address}
 					width="560px"
 				/>
 				<TextField
-					flag="normal"
+					inputFlag="normal"
 					name="step2"
 					id="store-address-detail"
 					placeholder="(필수) 상세주소를 입력해주세요"
@@ -221,7 +221,7 @@ const Step2 = () => {
 						홍보 채널 (선택)
 					</Typography>
 				</label>
-				<TextField name="step2" id="PromotionalChannel" flag="normal" width="320px" />
+				<TextField name="step2" id="PromotionalChannel" inputFlag="normal" width="320px" />
 				<Typography variant="p" aggressive="body_oneline_004" color={theme.colors.gray_005}>
 					인스타그램, 블로그, 홈페이지 중 가장 활발히 사용하고 있는 채널 하나를 선택해서 링크 입력해주세요
 				</Typography>
@@ -255,7 +255,7 @@ const Step2 = () => {
 						휴무일
 					</Typography>
 				</label>
-				<TextField name="step2" id="dayOff" flag="normal" width="320px" />
+				<TextField name="step2" id="dayOff" inputFlag="normal" width="320px" />
 				<StyledLayout.FlexBox style={{ paddingTop: '4px' }}>
 					<Typography variant="p" aggressive="body_oneline_004" color={theme.colors.gray_005}>
 						ex) 연중 무휴, 매주 토요일, 매달 둘째 및 넷째주 토요일 등

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -12,10 +12,11 @@ import {
 	RadioBtn,
 	StoreImageBtn,
 } from 'components/feature';
-import { extractBusinessLicenseExceptHyhpen } from 'core/storeRegistrationService';
+import { checkEmptyInputError, extractBusinessLicenseExceptHyhpen } from 'core/storeRegistrationService';
 import style from 'styles/style';
 import { theme } from 'styles';
 import { EmptyStoreImg } from 'public/static/images';
+import { useStep2Store } from 'store/actions/storeRegistrationStore';
 
 interface IBusinessLicenseStatusResponse {
 	match_cnt: number;
@@ -44,6 +45,14 @@ const Step2 = () => {
 	const [businessLicenseStatus, setBusinessLicenseStatus] = useState<'normal' | 'success' | 'error'>('normal');
 	const [selectedStoreImageBtn, setSelectedStoreImageBtn] = useState('defaultImage');
 	const [selectedBusinessHourBtn, setSelectedBusinessHourBtn] = useState('weekDaysWeekEnd');
+	const { inputArr, changeError, changeNormal } = useStep2Store();
+	const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const emptyInput = checkEmptyInputError(e.currentTarget.step2, changeError);
+		if (emptyInput !== 0) return;
+
+		// 여기서부터 서버 api 연결 로직
+	};
 	const handleSelectedStoreImageBtn = (e: React.ChangeEvent<HTMLInputElement>) => {
 		if (selectedStoreImageBtn === e.target.value) return;
 		setSelectedStoreImageBtn(e.target.value);
@@ -54,7 +63,8 @@ const Step2 = () => {
 	};
 	const handleExtractedPostCode = (extractedPostcode: string[]) => {
 		const [zonecode, address] = extractedPostcode;
-
+		if (zonecode !== '') changeNormal(3);
+		if (address !== '') changeNormal(4);
 		setStorePostcodeInputs({
 			...storePostcodeInputs,
 			zonecode,
@@ -68,7 +78,10 @@ const Step2 = () => {
 		});
 	};
 	const handleHoverState = () => {
-		if (businessLicenseStatus === 'error') setBusinessLicenseStatus('normal');
+		if (businessLicenseStatus === 'error') {
+			setBusinessLicenseStatus('normal');
+		}
+		changeNormal(0);
 	};
 
 	const handleBusinessLicenseStatusCheck = async () => {
@@ -103,11 +116,8 @@ const Step2 = () => {
 		businessLicenseInputRef.current.blur();
 	};
 
-	const handleOnClick = (e: FormEvent<HTMLFormElement>) => {
-		e.preventDefault();
-	};
 	return (
-		<form onSubmit={handleOnClick}>
+		<form onSubmit={handleOnSubmit}>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="businessLicense">
 					<Typography variant="h2" aggressive="body_oneline_004" color={theme.colors.gray_005}>
@@ -119,7 +129,8 @@ const Step2 = () => {
 						businessLicenseTextFieldRef={businessLicenseInputRef}
 						name="step2"
 						id="businessLicense"
-						inputFlag={businessLicenseStatus}
+						inputFlag={inputArr[0]}
+						isAuthorizedNumber={businessLicenseStatus}
 						onFocus={handleHoverState}
 					/>
 					<StoreResistrationSmallBtn width={{ width: '106px' }} onClick={handleBusinessLicenseStatusCheck}>
@@ -133,7 +144,7 @@ const Step2 = () => {
 						상호
 					</Typography>
 				</label>
-				<TextField name="step2" id="storeName" inputFlag="normal" width="320px" />
+				<TextField name="step2" id="storeName" onFocus={() => changeNormal(1)} inputFlag={inputArr[1]} width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="storeTelephoneNumber">
@@ -141,7 +152,7 @@ const Step2 = () => {
 						매장 전화번호
 					</Typography>
 				</label>
-				<TextField name="step2" id="storeTelephoneNumber" inputFlag="normal" width="320px" />
+				<TextField name="step2" id="storeTelephoneNumber" onFocus={() => changeNormal(2)} inputFlag={inputArr[2]} width="320px" />
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="store-address-detail">
@@ -152,7 +163,7 @@ const Step2 = () => {
 				<StyledLayout.FlexBox gap="6px">
 					<TextField
 						readOnly={true}
-						inputFlag="normal"
+						inputFlag={inputArr[3]}
 						name="step2"
 						id="store-postcode"
 						value={storePostcodeInputs.zonecode}
@@ -163,14 +174,15 @@ const Step2 = () => {
 
 				<TextField
 					readOnly={true}
-					inputFlag="normal"
+					inputFlag={inputArr[4]}
 					name="step2"
 					id="store-address"
 					value={storePostcodeInputs.address}
 					width="560px"
 				/>
 				<TextField
-					inputFlag="normal"
+					onFocus={() => changeNormal(5)}
+					inputFlag={inputArr[5]}
 					name="step2"
 					id="store-address-detail"
 					placeholder="(필수) 상세주소를 입력해주세요"
@@ -255,7 +267,7 @@ const Step2 = () => {
 						휴무일
 					</Typography>
 				</label>
-				<TextField name="step2" id="dayOff" inputFlag="normal" width="320px" />
+				<TextField name="step2" id="dayOff" inputFlag={inputArr[6]} onFocus={() => changeNormal(6)} width="320px" />
 				<StyledLayout.FlexBox style={{ paddingTop: '4px' }}>
 					<Typography variant="p" aggressive="body_oneline_004" color={theme.colors.gray_005}>
 						ex) 연중 무휴, 매주 토요일, 매달 둘째 및 넷째주 토요일 등

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -145,7 +145,14 @@ const Step2 = () => {
 						상호
 					</Typography>
 				</label>
-				<TextField name="step2" id="storeName" onFocus={() => changeNormal(1)} inputFlag={inputArr[1]} width="320px" />
+				<TextField
+					emptyErrorMessage="상호를"
+					name="step2"
+					id="storeName"
+					onFocus={() => changeNormal(1)}
+					inputFlag={inputArr[1]}
+					width="320px"
+				/>
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="storeTelephoneNumber">
@@ -153,7 +160,14 @@ const Step2 = () => {
 						매장 전화번호
 					</Typography>
 				</label>
-				<TextField name="step2" id="storeTelephoneNumber" onFocus={() => changeNormal(2)} inputFlag={inputArr[2]} width="320px" />
+				<TextField
+					emptyErrorMessage="매장 전화번호를"
+					name="step2"
+					id="storeTelephoneNumber"
+					onFocus={() => changeNormal(2)}
+					inputFlag={inputArr[2]}
+					width="320px"
+				/>
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="store-address-detail">
@@ -163,6 +177,7 @@ const Step2 = () => {
 				</label>
 				<StyledLayout.FlexBox gap="6px">
 					<TextField
+						emptyErrorMessage="매장 주소를"
 						readOnly={true}
 						inputFlag={inputArr[3]}
 						name="step2"
@@ -174,6 +189,7 @@ const Step2 = () => {
 				</StyledLayout.FlexBox>
 
 				<TextField
+					emptyErrorMessage="매장 주소를"
 					readOnly={true}
 					inputFlag={inputArr[4]}
 					name="step2"
@@ -182,6 +198,7 @@ const Step2 = () => {
 					width="560px"
 				/>
 				<TextField
+					emptyErrorMessage="상세 주소를"
 					onFocus={() => changeNormal(5)}
 					inputFlag={inputArr[5]}
 					name="step2"
@@ -268,7 +285,14 @@ const Step2 = () => {
 						휴무일
 					</Typography>
 				</label>
-				<TextField name="step2" id="dayOff" inputFlag={inputArr[6]} onFocus={() => changeNormal(6)} width="320px" />
+				<TextField
+					emptyErrorMessage="휴무일을"
+					name="step2"
+					id="dayOff"
+					inputFlag={inputArr[7]}
+					onFocus={() => changeNormal(7)}
+					width="320px"
+				/>
 				<StyledLayout.FlexBox style={{ paddingTop: '4px' }}>
 					<Typography variant="p" aggressive="body_oneline_004" color={theme.colors.gray_005}>
 						ex) 연중 무휴, 매주 토요일, 매달 둘째 및 넷째주 토요일 등

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -83,9 +83,9 @@ const Step2 = () => {
 			},
 		);
 
-		const { b_stt_cd } = businessLicenseStatusResponse.data.data[0];
+		const { b_stt_cd, tax_type } = businessLicenseStatusResponse.data.data[0];
 
-		if (businessLicenseStatusResponse.data.data[0].tax_type === '국세청에 등록되지 않은 사업자등록번호입니다.') {
+		if (tax_type === '국세청에 등록되지 않은 사업자등록번호입니다.') {
 			setBusinessLicenseStatus('error');
 		}
 		if (b_stt_cd === '01') {
@@ -210,7 +210,6 @@ const Step2 = () => {
 						<Typography variant="p" aggressive="body_oneline_004" color={theme.colors.gray_005}>
 							준비하신 이미지로 가게 사진을 등록해드려요
 						</Typography>
-
 						<StyledLayout.EmptyBoxDivider height="0" />
 						{selectedStoreImageBtn === 'registerImage' && <StoreImageBtn />}
 					</StyledLayout.FlexBox>

--- a/components/feature/BusinessLicenseTextField/index.tsx
+++ b/components/feature/BusinessLicenseTextField/index.tsx
@@ -43,7 +43,7 @@ const BusinessLicenseTextField = ({ businessLicenseTextFieldRef, inputFlag, ...p
 				disabled={inputFlag === 'success'}
 				onChange={handleBusinessLicense}
 				onKeyDown={checkKey}
-				onMouseDown={props.onMouseDown}
+				onFocus={props.onFocus}
 			/>
 
 			{inputFlag === 'error' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}

--- a/components/feature/BusinessLicenseTextField/index.tsx
+++ b/components/feature/BusinessLicenseTextField/index.tsx
@@ -3,7 +3,7 @@ import * as S from '../TextField/styled';
 
 type Props = {
 	inputFlag: 'normal' | 'error';
-	isAuthorizedNumber: 'normal' | 'success' | 'error';
+	isAuthorizedNumber: 'normal' | 'success' | 'error' | 'notClicked';
 	businessLicenseTextFieldRef: RefObject<HTMLInputElement>;
 } & React.ComponentProps<'input'>;
 
@@ -47,8 +47,9 @@ const BusinessLicenseTextField = ({ isAuthorizedNumber, businessLicenseTextField
 				onKeyDown={checkKey}
 				onFocus={props.onFocus}
 			/>
-
-			{(inputFlag === 'error' || isAuthorizedNumber === 'error') && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
+			{inputFlag === 'error' && <S.StyledMessage>사업자 번호를 입력해주세요</S.StyledMessage>}
+			{props.value !== '' && isAuthorizedNumber === 'notClicked' && <S.StyledMessage>사업자 번호를 조회해주세요</S.StyledMessage>}
+			{isAuthorizedNumber === 'error' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
 			{isAuthorizedNumber === 'success' && <S.SuccessMessage>✓ 입점가능한 사업자 번호입니다.</S.SuccessMessage>}
 		</S.TextFieldContainer>
 	);

--- a/components/feature/BusinessLicenseTextField/index.tsx
+++ b/components/feature/BusinessLicenseTextField/index.tsx
@@ -47,11 +47,13 @@ const BusinessLicenseTextField = ({ isAuthorizedNumber, businessLicenseTextField
 				onKeyDown={checkKey}
 				onFocus={props.onFocus}
 			/>
-			{inputFlag === 'error' && <S.StyledMessage>사업자 번호를 입력해주세요</S.StyledMessage>}
-			{props.value !== '' && isAuthorizedNumber === 'notClicked' && (
+			{(inputFlag === 'error' || (isAuthorizedNumber === 'error' && businessLicense === '')) && (
+				<S.StyledMessage>사업자 번호를 입력해주세요</S.StyledMessage>
+			)}
+			{businessLicense !== '' && isAuthorizedNumber === 'notClicked' && (
 				<S.StyledMessage>우측의 버튼을 눌러 조회해주세요</S.StyledMessage>
 			)}
-			{isAuthorizedNumber === 'error' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
+			{isAuthorizedNumber === 'error' && businessLicense !== '' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
 			{isAuthorizedNumber === 'success' && <S.SuccessMessage>✓ 입점가능한 사업자 번호입니다.</S.SuccessMessage>}
 		</S.TextFieldContainer>
 	);

--- a/components/feature/BusinessLicenseTextField/index.tsx
+++ b/components/feature/BusinessLicenseTextField/index.tsx
@@ -48,7 +48,9 @@ const BusinessLicenseTextField = ({ isAuthorizedNumber, businessLicenseTextField
 				onFocus={props.onFocus}
 			/>
 			{inputFlag === 'error' && <S.StyledMessage>사업자 번호를 입력해주세요</S.StyledMessage>}
-			{props.value !== '' && isAuthorizedNumber === 'notClicked' && <S.StyledMessage>사업자 번호를 조회해주세요</S.StyledMessage>}
+			{props.value !== '' && isAuthorizedNumber === 'notClicked' && (
+				<S.StyledMessage>우측의 버튼을 눌러 조회해주세요</S.StyledMessage>
+			)}
 			{isAuthorizedNumber === 'error' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
 			{isAuthorizedNumber === 'success' && <S.SuccessMessage>✓ 입점가능한 사업자 번호입니다.</S.SuccessMessage>}
 		</S.TextFieldContainer>

--- a/components/feature/BusinessLicenseTextField/index.tsx
+++ b/components/feature/BusinessLicenseTextField/index.tsx
@@ -2,11 +2,12 @@ import { ChangeEvent, KeyboardEvent, RefObject, useState } from 'react';
 import * as S from '../TextField/styled';
 
 type Props = {
-	inputFlag: 'normal' | 'success' | 'error';
+	inputFlag: 'normal' | 'error';
+	isAuthorizedNumber: 'normal' | 'success' | 'error';
 	businessLicenseTextFieldRef: RefObject<HTMLInputElement>;
 } & React.ComponentProps<'input'>;
 
-const BusinessLicenseTextField = ({ businessLicenseTextFieldRef, inputFlag, ...props }: Props) => {
+const BusinessLicenseTextField = ({ isAuthorizedNumber, businessLicenseTextFieldRef, inputFlag, ...props }: Props) => {
 	const [businessLicense, setBusinessLicense] = useState<string>('');
 	const [currentKey, setCurrentKey] = useState<string>('');
 	const handleBusinessLicense = (e: ChangeEvent<HTMLInputElement>) => {
@@ -33,21 +34,22 @@ const BusinessLicenseTextField = ({ businessLicenseTextFieldRef, inputFlag, ...p
 			<S.StyledTextFiled
 				readOnly={false}
 				style={{ width: '320px' }}
-				flag={inputFlag}
+				inputFlag={inputFlag}
+				isAuthorizedNumber={isAuthorizedNumber}
 				ref={businessLicenseTextFieldRef}
 				type="search"
 				placeholder="입력해주세요"
 				name={props.name}
 				id={props.id}
 				value={businessLicense}
-				disabled={inputFlag === 'success'}
+				disabled={isAuthorizedNumber === 'success'}
 				onChange={handleBusinessLicense}
 				onKeyDown={checkKey}
 				onFocus={props.onFocus}
 			/>
 
-			{inputFlag === 'error' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
-			{inputFlag === 'success' && <S.SuccessMessage>✓ 입점가능한 사업자 번호입니다.</S.SuccessMessage>}
+			{(inputFlag === 'error' || isAuthorizedNumber === 'error') && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
+			{isAuthorizedNumber === 'success' && <S.SuccessMessage>✓ 입점가능한 사업자 번호입니다.</S.SuccessMessage>}
 		</S.TextFieldContainer>
 	);
 };

--- a/components/feature/Button/StoreResistrationSmallBtn/index.tsx
+++ b/components/feature/Button/StoreResistrationSmallBtn/index.tsx
@@ -7,7 +7,7 @@ type Props = {
 } & React.ComponentProps<'button'>;
 const StoreResistrationSmallBtn = ({ children, ...props }: Props) => {
 	return (
-		<SmallBtnContainer onClick={props.onClick} style={props.width}>
+		<SmallBtnContainer onClick={props.onClick} type={props.type} style={props.width}>
 			<Typography variant="span" aggressive="button_001">
 				{children}
 			</Typography>

--- a/components/feature/Tab/index.tsx
+++ b/components/feature/Tab/index.tsx
@@ -12,31 +12,32 @@ const Tab = () => {
 		{ id: 2, step: 'Step2', title: '매장정보' },
 		{ id: 3, step: 'Step3', title: '상품정보' },
 	];
-	const [currentStep, setCurrentStep] = useState(0);
-	const checkDetailUI = (elementId: number) => {
-		if (elementId === 3 || elementId + 1 === currentStep) return !addBorderRight;
+	const [selectedStep, setSelectedStep] = useState(0);
+	const checkDetailUI = (curElement: number) => {
+		const nextElement = curElement + 1;
+		if (curElement === 3 || nextElement === selectedStep) return !addBorderRight;
 		return addBorderRight;
 	};
 	useEffect(() => {
 		if (pathname !== '/registration' && pathname !== null) {
-			setCurrentStep(() => Number(pathname[pathname.length - 1]));
+			setSelectedStep(Number(pathname[pathname.length - 1]));
 		}
 	}, [pathname]);
 	return (
 		<TabContainer>
 			{tabElementArr.map(({ id, step, title }) => {
 				return (
-					<TabElement borderRight={checkDetailUI(id)} key={step} isSelected={id === currentStep}>
+					<TabElement borderRight={checkDetailUI(id)} key={step} isSelected={id === selectedStep}>
 						<Typography
 							variant="h2"
-							color={id === currentStep ? theme.colors.primary_010 : theme.colors.gray_003}
+							color={id === selectedStep ? theme.colors.primary_010 : theme.colors.gray_003}
 							aggressive="body_oneline_005"
 						>
 							{step}
 						</Typography>
 						<Typography
 							variant="span"
-							color={id === currentStep ? theme.colors.gray_007 : theme.colors.gray_004}
+							color={id === selectedStep ? theme.colors.gray_007 : theme.colors.gray_004}
 							aggressive="tab_002"
 						>
 							{title}

--- a/components/feature/TextField/index.tsx
+++ b/components/feature/TextField/index.tsx
@@ -1,33 +1,26 @@
-import { useState } from 'react';
 import * as S from './styled';
 
 type Props = {
-	flag: 'normal' | 'success' | 'error';
+	inputFlag: 'normal' | 'success' | 'error';
 } & React.ComponentProps<'input'>;
 
-const TextField = (props: Props) => {
-	const [flag, setFlag] = useState<string>(props.flag);
-
-	const handleError = () => {
-		if (flag === 'normal') return;
-		setFlag('normal');
-	};
-
+const TextField = ({ inputFlag, ...props }: Props) => {
 	return (
 		<S.TextFieldContainer>
 			<S.StyledTextFiled
 				readOnly={props.readOnly ?? false}
 				name={props.name}
 				id={props.id}
-				onFocus={handleError}
-				flag={flag}
+				onFocus={props.onFocus}
+				flag={inputFlag}
 				onChange={props.onChange}
+				onMouseDown={props.onMouseDown}
 				style={{ width: props.width }}
 				value={props.value}
 				placeholder={props.placeholder ?? '입력해주세요'}
 				type="search"
 			/>
-			{flag === 'error' && <S.StyledMessage>경고메시지 자리에요</S.StyledMessage>}
+			{inputFlag === 'error' && <S.StyledMessage>경고메시지 자리에요</S.StyledMessage>}
 		</S.TextFieldContainer>
 	);
 };

--- a/components/feature/TextField/index.tsx
+++ b/components/feature/TextField/index.tsx
@@ -2,9 +2,10 @@ import * as S from './styled';
 
 type Props = {
 	inputFlag: 'normal' | 'success' | 'error';
+	emptyErrorMessage?: string;
 } & React.ComponentProps<'input'>;
 
-const TextField = ({ inputFlag, ...props }: Props) => {
+const TextField = ({ inputFlag, emptyErrorMessage, ...props }: Props) => {
 	return (
 		<S.TextFieldContainer>
 			<S.StyledTextFiled
@@ -20,7 +21,7 @@ const TextField = ({ inputFlag, ...props }: Props) => {
 				placeholder={props.placeholder ?? '입력해주세요'}
 				type="search"
 			/>
-			{inputFlag === 'error' && <S.StyledMessage>경고메시지 자리에요</S.StyledMessage>}
+			{inputFlag === 'error' && <S.StyledMessage>{`${emptyErrorMessage} 입력해주세요`}</S.StyledMessage>}
 		</S.TextFieldContainer>
 	);
 };

--- a/components/feature/TextField/index.tsx
+++ b/components/feature/TextField/index.tsx
@@ -12,7 +12,7 @@ const TextField = ({ inputFlag, ...props }: Props) => {
 				name={props.name}
 				id={props.id}
 				onFocus={props.onFocus}
-				flag={inputFlag}
+				inputFlag={inputFlag}
 				onChange={props.onChange}
 				onMouseDown={props.onMouseDown}
 				style={{ width: props.width }}

--- a/components/feature/TextField/styled.ts
+++ b/components/feature/TextField/styled.ts
@@ -5,8 +5,10 @@ export const TextFieldContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 `;
-export const StyledTextFiled = styled.input<{ flag: string; readOnly: boolean }>`
-	border: 1px solid ${({ theme, flag }) => (flag === 'error' ? theme.colors.error : theme.colors.gray_002)};
+export const StyledTextFiled = styled.input<{ inputFlag: string; readOnly: boolean; isAuthorizedNumber?: string | undefined }>`
+	border: 1px solid
+		${({ theme, inputFlag, isAuthorizedNumber }) =>
+			inputFlag === 'error' || isAuthorizedNumber === 'error' ? theme.colors.error : theme.colors.gray_002};
 	padding: 8px 16px;
 	height: 48px;
 	border-radius: 10px;

--- a/components/feature/TextField/styled.ts
+++ b/components/feature/TextField/styled.ts
@@ -8,7 +8,9 @@ export const TextFieldContainer = styled.div`
 export const StyledTextFiled = styled.input<{ inputFlag: string; readOnly: boolean; isAuthorizedNumber?: string | undefined }>`
 	border: 1px solid
 		${({ theme, inputFlag, isAuthorizedNumber }) =>
-			inputFlag === 'error' || isAuthorizedNumber === 'error' ? theme.colors.error : theme.colors.gray_002};
+			inputFlag === 'error' || isAuthorizedNumber === 'error' || isAuthorizedNumber === 'notClicked'
+				? theme.colors.error
+				: theme.colors.gray_002};
 	padding: 8px 16px;
 	height: 48px;
 	border-radius: 10px;

--- a/core/storeRegistrationService.ts
+++ b/core/storeRegistrationService.ts
@@ -4,3 +4,13 @@ export const extractBusinessLicenseExceptHyhpen = (businessLicense: string) => {
 		.filter((c) => c !== '-')
 		.join('');
 };
+export const checkEmptyInputError = (inputArr: RadioNodeList, changeError: (id: number) => void) => {
+	let emptyInput = 0;
+	for (let i = 0; i < inputArr.length; i++) {
+		if ((inputArr[i] as HTMLInputElement).value === '') {
+			changeError(i);
+			emptyInput++;
+		}
+	}
+	return emptyInput;
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"react-dom": "18.2.0",
 		"styled-components": "^5.3.6",
 		"styled-normalize": "^8.0.7",
-		"typescript": "*"
+		"typescript": "*",
+		"zustand": "^4.3.2"
 	},
 	"devDependencies": {
 		"@svgr/webpack": "^6.5.1",

--- a/store/actions/index.ts
+++ b/store/actions/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * as storeRegistrationStore from './storeRegistrationStore';

--- a/store/actions/storeRegistrationStore.ts
+++ b/store/actions/storeRegistrationStore.ts
@@ -6,13 +6,17 @@ export interface stepInputs {
 	changeNormal: (id: number) => void;
 }
 
-export const useStep1Store = create<stepInputs>((set, get) => ({
-	inputArr: ['normal', 'normal', 'normal'],
-	changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
-	changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
-}));
-export const useStep2Store = create<stepInputs>((set, get) => ({
-	inputArr: ['normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal'],
-	changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
-	changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
-}));
+export const useStep1Store = create<stepInputs>()(
+	devtools((set, get) => ({
+		inputArr: ['normal', 'normal', 'normal'],
+		changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
+		changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
+	})),
+);
+export const useStep2Store = create<stepInputs>()(
+	devtools((set, get) => ({
+		inputArr: ['normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal'],
+		changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
+		changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
+	})),
+);

--- a/store/actions/storeRegistrationStore.ts
+++ b/store/actions/storeRegistrationStore.ts
@@ -1,13 +1,18 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 export interface stepInputs {
-	inputArr: Array<'normal' | 'success' | 'error'>;
+	inputArr: Array<'normal' | 'error'>;
 	changeError: (id: number) => void;
 	changeNormal: (id: number) => void;
 }
 
-export const useStep1Store = create<stepInputs>((set) => ({
+export const useStep1Store = create<stepInputs>((set, get) => ({
 	inputArr: ['normal', 'normal', 'normal'],
 	changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
-	changeNormal: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
+	changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
+}));
+export const useStep2Store = create<stepInputs>((set, get) => ({
+	inputArr: ['normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal'],
+	changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
+	changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
 }));

--- a/store/actions/storeRegistrationStore.ts
+++ b/store/actions/storeRegistrationStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+interface stepInputs {
+	inputArr: string[];
+	changeError: (id: number) => void;
+	changeNormal: (id: number) => void;
+}
+
+const useStep1Store = create<stepInputs>((set) => ({
+	inputArr: ['normal', 'normal', 'normal'],
+	changeError: (id) =>
+		set((state) => ({ inputArr: state.inputArr.map((inputFlag: string, idx: number) => (idx === id ? 'error' : inputFlag)) })),
+
+	changeNormal: (id) =>
+		set((state) => ({ inputArr: state.inputArr.map((inputFlag: string, idx: number) => (idx === id ? 'normal' : inputFlag)) })),
+}));

--- a/store/actions/storeRegistrationStore.ts
+++ b/store/actions/storeRegistrationStore.ts
@@ -1,16 +1,13 @@
 import { create } from 'zustand';
-
-interface stepInputs {
-	inputArr: string[];
+import { devtools } from 'zustand/middleware';
+export interface stepInputs {
+	inputArr: Array<'normal' | 'success' | 'error'>;
 	changeError: (id: number) => void;
 	changeNormal: (id: number) => void;
 }
 
-const useStep1Store = create<stepInputs>((set) => ({
+export const useStep1Store = create<stepInputs>((set) => ({
 	inputArr: ['normal', 'normal', 'normal'],
-	changeError: (id) =>
-		set((state) => ({ inputArr: state.inputArr.map((inputFlag: string, idx: number) => (idx === id ? 'error' : inputFlag)) })),
-
-	changeNormal: (id) =>
-		set((state) => ({ inputArr: state.inputArr.map((inputFlag: string, idx: number) => (idx === id ? 'normal' : inputFlag)) })),
+	changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
+	changeNormal: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
 }));

--- a/store/actions/storeRegistrationStore.ts
+++ b/store/actions/storeRegistrationStore.ts
@@ -12,7 +12,7 @@ export const useStep1Store = create<stepInputs>((set, get) => ({
 	changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
 }));
 export const useStep2Store = create<stepInputs>((set, get) => ({
-	inputArr: ['normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal'],
+	inputArr: ['normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal'],
 	changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
 	changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
 }));

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,1 +1,2 @@
-export {};
+export * from './actions';
+export * from './atoms';

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,1 +1,2 @@
 export * as DomainType from './domain';
+export * as StoreRegistrationType from './storeRegistration';

--- a/types/storeRegistration.ts
+++ b/types/storeRegistration.ts
@@ -1,0 +1,17 @@
+export interface Step1ManagerInfo {
+	name: string; // 대표자명
+	email: string; // 이메일
+	phoneNumber: string; // 전화번호
+}
+export interface DaumPostcodeAttributes {
+	registrationNumber: string; // 사업자번호
+	name: string; // 상호
+	callNumber: string; // 매장 전화번호
+	address: string; // 매장 주소
+	latitude: string; // 위도
+	longitude: string; // 경도
+	imgPath: string; // 메징사진
+	instaAccount: string; // 홍보 채널(optional)
+	businessHour: string; // 운영시간
+	notice: string; // 휴무일
+}

--- a/types/storeRegistration.ts
+++ b/types/storeRegistration.ts
@@ -3,7 +3,7 @@ export interface Step1ManagerInfo {
 	email: string; // 이메일
 	phoneNumber: string; // 전화번호
 }
-export interface DaumPostcodeAttributes {
+export interface Step2StoreInfo {
 	registrationNumber: string; // 사업자번호
 	name: string; // 상호
 	callNumber: string; // 매장 전화번호

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,7 +4194,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-use-sync-external-store@^1.2.0:
+use-sync-external-store@1.2.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
@@ -4269,3 +4269,10 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zustand@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.2.tgz#bb121fcad84c5a569e94bd1a2695e1a93ba85d39"
+  integrity sha512-rd4haDmlwMTVWVqwvgy00ny8rtti/klRoZjFbL/MAcDnmD5qSw/RZc+Vddstdv90M5Lv6RPgWvm1Hivyn0QgJw==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
## 📎 Related Issues

- close #34 

<br />

## 📋 작업 내용

- [x] onSubmit에 맞는 로직 변경
- [x] step1,2 서버 요청 body interface 생성
- [x] textField props 적절하게 수정
- [x] input 값들 error 띄우기 (입력되지 않은 경우 처리)
- [x] 사업자 번호(미입력/미조회/잘못된 번호/올바른 번호) 경우의 수 나누기

<br />

## 🔎 PR Point
## 1. onSubmit 관련 로직

- 원래는 `onChange 핸들러`와 `value` 값으로 input 값을 변경해주고 제어했지만, form 으로 해당 step을 모두 묶은 후 step1, step2와 같이 `input name`을 통일해 `input value들을 한꺼번에 불러와 검사하고 error를 띄워주거나, 서버 api로 값을 보냄`
    - 현재 서버 api 연결 로직은 짜지 않은 상태 → 해당 방안, `빅터랑 이야기해볼 필요성 있다고 생각`해서!
    
    ```tsx
    // app/registration/step1/page.tsx
    
    const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
    		e.preventDefault();
    		const emptyInput = checkEmptyInputError(e.currentTarget.step1, changeError);
    		if (emptyInput !== 0) return;
    		// 여기서부터 서버 api 연결 로직
    	};
    
    // app/registration/step2/page.tsx
    
    const handleOnSubmit = (e: FormEvent<HTMLFormElement>) => {
    		e.preventDefault();
    		const emptyInput = checkEmptyInputError(e.currentTarget.step2, changeError);
    		if (e.currentTarget.step2[0].value !== '' && businessLicenseStatus === 'normal') setBusinessLicenseStatus('notClicked'); //해당 내용은 아래에 있음
    		if (emptyInput !== 0) return;
    
    		// 여기서부터 서버 api 연결 로직
    	};
    ```
    
    ```tsx
    // core/storeRegistraionService.ts
    // 빈 input 이 있는지 검사하고, 빈 input 개수를 넘겨주는 함수
    export const checkEmptyInputError = (inputArr: RadioNodeList, changeError: (id: number) => void) => {
    	let emptyInput = 0;
    	for (let i = 0; i < inputArr.length; i++) {
    		if ((inputArr[i] as HTMLInputElement).value === '') {
    			changeError(i);
    			emptyInput++;
    		}
    	}
    	return emptyInput;
    };
    ```
    
- 이미지 버튼이나 라디오 버튼들에 대한 상황은 고려하지 않고, 오직 TextField값만을 고려한 상황. 추후 이미지 버튼과 라디오버튼 form이 구현 완료되면 해당 로직도 보충해놓을 예정

## 2. TextField props

- 원래는 `inputFlag` 를 받아 TextField에서 따로 useState를 만들어주어 제어하려 했으나, `빅터의 변경사항(사업자 번호 textField)를 확인한 결과 샐리가 의도한 바가 맞기에 원래의 TextField 컴포넌트 또한 props를 변경`함
    
    ```tsx
    inputFlag: 'normal' | 'success' | 'error'; 
    emptyErrorMessage?: string; // 항목에 맞는 에러 메세지 띄워 주기 위함
    ```
    
- 위의 props 외에는, `React.ComponentProps<'input'>`에 포함된 프로퍼티로, 각각 필요한 상황이 있을 떄에만 쓰임(ex. onFocus로 error 값 해제해주는 함수 넘겨주어 focus된 것이라면 빨간색 테두리 없앤다.. )

## 3. Input 빈값 Error 처리(zustand 활용)

- `store/actions` 디렉토리 내에 `storeRegistrationStore.ts` 를 만들어 `각 step들마다 input 개수에 맞게 ‘normal’이 들어간 배열, 그리고 그 배열 값들을 ‘error’ / ‘normal’로 바꿔주는 action 들` 구현
- zustand는 atom의 개념이 없고, store 상태값과 액션들을 분리하는 경우가 잘 없어(내가 본 레퍼런스만 그랬을지도.. 혹시 좋은 레퍼런스 있다면 공유 부탁!) actions 에 다같이 만들었으나, 이후 recoil 또한 사용할 가능성이 없어 atoms 폴더를 지우지는 않았음
- 이에 대한 로직을 zustand를 통해 전역으로 선언하고 만들어둔 이유는, `비즈니스 로직을 분리하기도 쉽고 error 값들을 제어하는 곳이 한 번에 있는 것이 좋다고 판단`했기 때문 (다른 의견이 있다면 이에 대해서도 말해주세요!)
    
    ```tsx
    export interface stepInputs {
    	inputArr: Array<'normal' | 'error'>;
    	changeError: (id: number) => void; // 불변성을 지키며 하나의 값을 error로 변경
    	changeNormal: (id: number) => void; // 불변성을 지키며 하나의 값을 normal로 변경
    }
    
    export const useStep1Store = create<stepInputs>((set, get) => ({
    	inputArr: ['normal', 'normal', 'normal'],
    	changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
    	changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
    }));
    export const useStep2Store = create<stepInputs>((set, get) => ({
    	inputArr: ['normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal', 'normal'],
    	changeError: (id) => set((state) => ({ inputArr: { ...state.inputArr, [id]: 'error' } })),
    	changeNormal: (id) => get().inputArr[id] === 'error' && set((state) => ({ inputArr: { ...state.inputArr, [id]: 'normal' } })),
    }));
    ```
    

## 4. 사업자 등록번호 컴포넌트 변경사항

- 원래 사업자 등록번호 TextField에 대한 시나리오는 `사용자가 번호 조회버튼을 누름` → `1) 번호가 틀렸다거나` `2) 등록된 번호라거나` 둘 중 하나의 답을 보내주는 것으로만 처리되어 있었지만 구현하면서 `번호를 아예 미입력할시 / 입력된 번호를 조회하지 않을시/ 번호가 잘못되었을시 / 번호가 등록된 번호일시` 에 대한 경우로 나눠줌
- 보다 자세한 사항은 커밋 참조
    
    ```tsx
    {inputFlag === 'error' && <S.StyledMessage>사업자 번호를 입력해주세요</S.StyledMessage>}
    {props.value !== '' && isAuthorizedNumber === 'notClicked' && (
    				<S.StyledMessage>우측의 버튼을 눌러 조회해주세요</S.StyledMessage>
    			)}
    {isAuthorizedNumber === 'error' && <S.StyledMessage>사업자 번호를 확인해주세요</S.StyledMessage>}
    {isAuthorizedNumber === 'success' && <S.SuccessMessage>✓ 입점가능한 사업자 번호입니다.</S.SuccessMessage>}
    
    ```
    

## 5. 그외

- `storeRegistration.ts`
    - 입점신청페이지에서 서버로 넘겨주는 `body의 타입`들을 선언해두고자 `types 디렉토리`에 storeRegistration.ts 를 만듦
    - 이는 일단 구현은 해뒀는데, 추후 서버와의 회의 후 바뀔 가능성이 있음 (아직 사용 안 하기 때문에 상관없음)
        
        ```tsx
        export interface Step1ManagerInfo {
        	name: string; // 대표자명
        	email: string; // 이메일
        	phoneNumber: string; // 전화번호
        }
        export interface Step2StoreInfo {
        	registrationNumber: string; // 사업자번호
        	name: string; // 상호
        	callNumber: string; // 매장 전화번호
        	address: string; // 매장 주소
        	latitude: string; // 위도
        	longitude: string; // 경도
        	imgPath: string; // 메징사진
        	instaAccount: string; // 홍보 채널(optional)
        	businessHour: string; // 운영시간
        	notice: string; // 휴무일
        }
        ```
        
- `TextField Width 삭제`
    - 원래는 TextField에 디자인 시스템에 들어있는 width 외의 width값을 집어넣지 못하게 하기위해, styles/style.ts에 전역으로 TextField width값을 선언해두었으나 굳이 필요하지 않다고 생각해 이를 삭제하고 TextField 에 width라는 props에 string으로 `“—px"` 로 넘겨주기로 함
- `비즈니스 로직 미분리`
    - 현재 비즈니스 로직이 page 내에 전부 들어가있어 복잡하고 지저분.. 한 걸 알고 있어서 이를 분리하는 것까지 이번 브랜치에서 해보려 했으나, 아직 구현되지 않은 컴포넌트들이 많고 빠른 상황 공유를 위해 그냥 올림 → `step2까지의 컴포넌트들을 모두 작업한 후 한꺼번에 리팩토링 예정`!

<br />

## 😡 Trouble Shooting

- (이 작업을 하던 중에 발생했던 것)

<br />

## 👀 스크린샷 / GIF / 링크
- step1
![34-step1](https://user-images.githubusercontent.com/80065381/213883419-a5cbf557-0178-46af-80a5-c29ee24807cc.gif)

- step2(나머지는 step1과 같기에, 사업자등록번호 위주)
![34-step2](https://user-images.githubusercontent.com/80065381/213883421-b24f7409-0ff8-4877-b751-57f7b57ecffa.gif)

<br />

## ➕ 추가적인 태스크
- 이미지버튼 작업해서 로직에 추가
- timepicker 및 라디오 form 들 작업해서 로직에 추가


<br />

## 📚 Reference
[zustand 사용하기 🚀](https://coding-heesong.tistory.com/48)
[[TypeScript] e.target.target 타입 에러가 나는 이유 ts(2339)](https://nuhends.tistory.com/115)
[[react] 상!태!관!리! Zustand 를 아십니까?](https://velog.io/@ho2yahh/react-%EC%83%81%ED%83%9C%EA%B4%80%EB%A6%AC-Zustand-%EB%A5%BC-%EC%95%84%EC%8B%AD%EB%8B%88%EA%B9%8C)
[[react] 상!태!관!리! Zustand 를 아십니까?](https://blacklobster.tistory.com/3)
[[React 상태 관리 라이브러리 Zustand의 코드를 파헤쳐보자](https://ui.toast.com/posts/ko_20210812](https://ui.toast.com/posts/ko_20210812)
[zustand와 타입스크립트 [공식문서번역]](https://itchallenger.tistory.com/606)
<br />

## ✅ PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다. (개인 작업시에만 확인)
- [x] Critical 한 Error 또는 Warning 이 존재하지 않습니다. 
- [x] 브라우저에 console 이 존재하지 않습니다.
