### PR TITLE
[#39] 마이페이지 연관 Modal 플로우 연결(without. API 플로우 연동)

### DIFF
--- a/app/mypage/member/page.tsx
+++ b/app/mypage/member/page.tsx
@@ -1,11 +1,26 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
-import { MyPageSectionLeaveMember } from 'components/feature';
+import { useRouter } from 'next/navigation';
+import { MyPageSectionLeaveMember, LeaveMemberConfirmModal, LeaveMemberSuccessModal } from 'components/feature';
 import { StyledLayout, Typography } from 'components/shared';
+import useModalStore, { MODAL_KEY } from 'store/actions/modalStore';
 
 const MemberManagement = () => {
 	const { data } = useSession();
+	const router = useRouter();
+
+	const { modalKey, changeModalKey } = useModalStore();
+
+	const handleLeaveMemberConfirm = () => {
+		// 회원 탈퇴 API 요청 성공 시
+		changeModalKey(MODAL_KEY.ON_LEAVE_MEMBER_SUCCESS_MODAL);
+	};
+
+	const handleLeaveMemberSuccess = () => {
+		router.push('/');
+		changeModalKey(MODAL_KEY.OFF);
+	};
 
 	return (
 		<StyledLayout.FlexBox flexDirection="column">
@@ -14,6 +29,11 @@ const MemberManagement = () => {
 			</Typography>
 
 			<MyPageSectionLeaveMember memberEmail={data?.user?.email} />
+
+			{modalKey === MODAL_KEY.ON_LEAVE_MEMBER_CONFIRM_MODAL && (
+				<LeaveMemberConfirmModal onCancel={() => changeModalKey(MODAL_KEY.OFF)} onConfirm={handleLeaveMemberConfirm} />
+			)}
+			{modalKey === MODAL_KEY.ON_LEAVE_MEMBER_SUCCESS_MODAL && <LeaveMemberSuccessModal onClick={handleLeaveMemberSuccess} />}
 		</StyledLayout.FlexBox>
 	);
 };

--- a/app/mypage/store/page.tsx
+++ b/app/mypage/store/page.tsx
@@ -1,34 +1,63 @@
 'use client';
 
-import { MyPageSectionEmptyStore, MyPageSectionRegisteredStore } from 'components/feature';
+import {
+	MyPageSectionEmptyStore,
+	MyPageSectionRegisteredStore,
+	StoreRegistrationCancelConfirmModal,
+	StoreRegistrationCancelSuccessModal,
+} from 'components/feature';
 import { StyledLayout, Typography } from 'components/shared';
 import { MyPageSectionDescriptionWarpper, MyPageSectionDescription } from 'components/feature/MyPageSection/styled';
 import { theme } from 'styles';
+import useModalStore, { MODAL_KEY } from 'store/actions/modalStore';
 
 const StoreManagement = () => {
+	const { modalKey, changeModalKey } = useModalStore();
+
+	const handleStoreRegistrationCancelConfirm = () => {
+		// 입점 매장 철회 API 요청 & Mutation
+
+		changeModalKey(MODAL_KEY.ON_STORE_REGISTRATION_CANCEL_SUCCESS_MODAL);
+	};
+
 	return (
 		<StyledLayout.FlexBox flexDirection="column" margin="84px 0">
 			<Typography variant="h2" aggressive="headline_oneline_003" margin="0 0 20px 0">
 				매장 및 상품 정보 관리
 			</Typography>
 			<MyPageSectionDescriptionWarpper>
-				<MyPageSectionDescription>
-					입점한 매장의 매장 정보와 상품 정보를 직접 관리(추가, 삭제, 수정 등)할 수 있습니다.
-				</MyPageSectionDescription>
-				<MyPageSectionDescription>
-					추가, 삭제 등 변경사항이 있는 정보는 익일 새벽 00:00시 Pump 서비스에 한꺼번에 반영됩니다.
-				</MyPageSectionDescription>
+				{true ? (
+					<>
+						<MyPageSectionDescription>
+							입점한 매장의 매장 정보와 상품 정보를 직접 관리(추가, 삭제, 수정 등)할 수 있습니다.
+						</MyPageSectionDescription>
+						<MyPageSectionDescription>
+							추가, 삭제 등 변경사항이 있는 정보는 익일 새벽 00:00시 Pump 서비스에 한꺼번에 반영됩니다.
+						</MyPageSectionDescription>
+					</>
+				) : (
+					<>
+						<MyPageSectionDescription>
+							Pump 입점을 위해 [입점 신청하기] 버튼을 눌러 입점신청서를 먼저 작성해주세요.
+						</MyPageSectionDescription>
+					</>
+				)}
 			</MyPageSectionDescriptionWarpper>
 
-			{false ? (
-				<MyPageSectionEmptyStore />
-			) : (
-				<>
-					<Typography variant="h3" aggressive="body_oneline_004" color={theme.colors.gray_005} margin="14px 0">
-						매장
-					</Typography>
-					<MyPageSectionRegisteredStore />
-				</>
+			<Typography variant="h3" aggressive="body_oneline_004" color={theme.colors.gray_005} margin="0 0 14px 0">
+				매장
+			</Typography>
+			{true ? <MyPageSectionRegisteredStore /> : <MyPageSectionEmptyStore />}
+
+			{modalKey === MODAL_KEY.ON_STORE_REGISTRATION_CANCEL_CONFIRM_MODAL && (
+				<StoreRegistrationCancelConfirmModal
+					onCancel={() => changeModalKey(MODAL_KEY.OFF)}
+					onConfirm={handleStoreRegistrationCancelConfirm}
+				/>
+			)}
+
+			{modalKey === MODAL_KEY.ON_STORE_REGISTRATION_CANCEL_SUCCESS_MODAL && (
+				<StoreRegistrationCancelSuccessModal onClick={() => changeModalKey(MODAL_KEY.OFF)} />
 			)}
 		</StyledLayout.FlexBox>
 	);

--- a/components/feature/Modal/Common/ConfirmModal/index.tsx
+++ b/components/feature/Modal/Common/ConfirmModal/index.tsx
@@ -2,6 +2,11 @@ import { ReactNode } from 'react';
 import { ModalFrame, LargeBtn } from 'components/shared';
 import style from 'styles/style';
 
+export type ConfirmModalEvent = {
+	onCancel: () => void;
+	onConfirm: () => void;
+};
+
 type Props = {
 	modalTitle: ReactNode;
 	modalDescription: ReactNode;

--- a/components/feature/Modal/Common/InfoModal/index.tsx
+++ b/components/feature/Modal/Common/InfoModal/index.tsx
@@ -2,6 +2,10 @@ import { ReactNode } from 'react';
 import { ModalFrame, LargeBtn } from 'components/shared';
 import style from 'styles/style';
 
+export type InfoModalEvent = {
+	onClick: () => void;
+};
+
 type Props = {
 	modalTitle: ReactNode;
 	modalDescription: ReactNode;

--- a/components/feature/Modal/LeaveMemberConfirmModal/index.tsx
+++ b/components/feature/Modal/LeaveMemberConfirmModal/index.tsx
@@ -1,6 +1,7 @@
 import { ConfirmModal } from 'components/feature/Modal';
+import { ConfirmModalEvent } from 'components/feature/Modal/Common/ConfirmModal';
 
-const LeaveMemberConfirmModal = () => {
+const LeaveMemberConfirmModal = ({ onCancel, onConfirm }: ConfirmModalEvent) => {
 	return (
 		<ConfirmModal
 			modalTitle="회원 탈퇴하시겠습니까?"
@@ -8,11 +9,11 @@ const LeaveMemberConfirmModal = () => {
 			modalBtn={{
 				cancel: {
 					text: '취소',
-					onCancel: () => {},
+					onCancel,
 				},
 				confirm: {
 					text: '탈퇴하기',
-					onConfirm: () => {},
+					onConfirm,
 				},
 			}}
 		/>

--- a/components/feature/Modal/LeaveMemberSuccessModal/index.tsx
+++ b/components/feature/Modal/LeaveMemberSuccessModal/index.tsx
@@ -1,6 +1,7 @@
 import { InfoModal } from 'components/feature/Modal';
+import { InfoModalEvent } from 'components/feature/Modal/Common/InfoModal';
 
-const LeaveMemberSuccessModal = () => {
+const LeaveMemberSuccessModal = ({ onClick }: InfoModalEvent) => {
 	return (
 		<InfoModal
 			modalTitle="회원 탈퇴가 되었습니다."
@@ -8,7 +9,7 @@ const LeaveMemberSuccessModal = () => {
 			modalBtn={{
 				type: 'primary',
 				text: '확인',
-				onClick: () => {},
+				onClick,
 			}}
 		/>
 	);

--- a/components/feature/Modal/StoreRegistrationCancelConfirmModal/index.tsx
+++ b/components/feature/Modal/StoreRegistrationCancelConfirmModal/index.tsx
@@ -1,6 +1,7 @@
 import { ConfirmModal } from 'components/feature/Modal';
+import { ConfirmModalEvent } from 'components/feature/Modal/Common/ConfirmModal';
 
-const StoreRegistrationCancelConfirmModal = () => {
+const StoreRegistrationCancelConfirmModal = ({ onCancel, onConfirm }: ConfirmModalEvent) => {
 	return (
 		<ConfirmModal
 			modalTitle="매장 입점을 철회하시겠습니까 ?"
@@ -8,11 +9,11 @@ const StoreRegistrationCancelConfirmModal = () => {
 			modalBtn={{
 				cancel: {
 					text: '취소',
-					onCancel: () => {},
+					onCancel,
 				},
 				confirm: {
 					text: '철회하기',
-					onConfirm: () => {},
+					onConfirm,
 				},
 			}}
 		/>

--- a/components/feature/Modal/StoreRegistrationCancelSuccessModal/index.tsx
+++ b/components/feature/Modal/StoreRegistrationCancelSuccessModal/index.tsx
@@ -1,6 +1,7 @@
 import { InfoModal } from 'components/feature/Modal';
+import { InfoModalEvent } from 'components/feature/Modal/Common/InfoModal';
 
-const StoreRegistrationCancelSuccessModal = () => {
+const StoreRegistrationCancelSuccessModal = ({ onClick }: InfoModalEvent) => {
 	return (
 		<InfoModal
 			modalTitle="입점 철회되었습니다."
@@ -8,7 +9,7 @@ const StoreRegistrationCancelSuccessModal = () => {
 			modalBtn={{
 				type: 'primary',
 				text: '확인',
-				onClick: () => {},
+				onClick,
 			}}
 		/>
 	);

--- a/components/feature/MyPageSection/MyPageSectionLeaveMember/index.tsx
+++ b/components/feature/MyPageSection/MyPageSectionLeaveMember/index.tsx
@@ -1,3 +1,4 @@
+import useModalStore, { MODAL_KEY } from 'store/actions/modalStore';
 import * as S from '../styled';
 import { Typography } from 'components/shared';
 import { MyPageActionBtn } from 'components/feature';
@@ -7,12 +8,14 @@ type Props = {
 };
 
 const MyPageSectionLeaveMember = (props: Props) => {
+	const { changeModalKey } = useModalStore();
+
 	return (
 		<S.MyPageOneActionDescriptionWrapper>
 			<Typography aggressive="body_oneline_004" variant="p">
 				{props.memberEmail} 을 더 이상 사용하지 않으시나요?
 			</Typography>
-			<MyPageActionBtn buttonTheme="lightgray" onClick={() => console.info('회원 탈퇴하기 GO')}>
+			<MyPageActionBtn buttonTheme="lightgray" onClick={() => changeModalKey(MODAL_KEY.ON_LEAVE_MEMBER_CONFIRM_MODAL)}>
 				회원 탈퇴하기
 			</MyPageActionBtn>
 		</S.MyPageOneActionDescriptionWrapper>

--- a/components/feature/MyPageSection/MyPageSectionRegisteredStore/index.tsx
+++ b/components/feature/MyPageSection/MyPageSectionRegisteredStore/index.tsx
@@ -3,8 +3,11 @@ import { MyPageActionBtn } from 'components/feature';
 import * as S from './styled';
 import { theme } from 'styles';
 import { TrashIcon } from 'public/static/icons';
+import useModalStore, { MODAL_KEY } from 'store/actions/modalStore';
 
 const MyPageSectionRegisteredStore = () => {
+	const { changeModalKey } = useModalStore();
+
 	return (
 		<S.RegisteredStoreContainer>
 			<S.RegisteredStoreContentWrapper>
@@ -60,9 +63,7 @@ const MyPageSectionRegisteredStore = () => {
 				<StyledLayout.FlexBox flexDirection={'column'} justifyContent={'flex-start'} margin={'0 0 0 30px'}>
 					<S.RegisteredStoreDeleteBtn
 						type="button"
-						onClick={() => {
-							console.info('입점상점 삭제 GO');
-						}}
+						onClick={() => changeModalKey(MODAL_KEY.ON_STORE_REGISTRATION_CANCEL_CONFIRM_MODAL)}
 					>
 						<TrashIcon />
 					</S.RegisteredStoreDeleteBtn>

--- a/components/feature/MyPageSection/styled.ts
+++ b/components/feature/MyPageSection/styled.ts
@@ -14,7 +14,6 @@ export const MyPageOneActionDescriptionWrapper = styled.div`
 	flex-direction: column;
 	align-items: center;
 	gap: 24px;
-	margin-top: 40px;
 	padding: 65px 0 73px 0;
 	border: 1px solid ${({ theme }) => theme.colors.gray_002};
 	border-radius: 4px;

--- a/components/feature/MyPageSideBar/index.tsx
+++ b/components/feature/MyPageSideBar/index.tsx
@@ -12,7 +12,7 @@ const myPageNavigations = [
 	{
 		id: 1,
 		path: '/mypage/store',
-		renderText: '가게 및 상품 정보 관리',
+		renderText: '매장 및 상품 정보 관리',
 	},
 	{
 		id: 2,

--- a/components/shared/ModalFrame/index.tsx
+++ b/components/shared/ModalFrame/index.tsx
@@ -5,25 +5,22 @@ import * as S from './styled';
 const ModalFrame = (props: PropsWithChildren) => {
 	return (
 		<ModalPortal>
-			<S.Container
-				style={{
-					position: 'fixed',
-					inset: 0,
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'center',
-					width: '100vw',
-					height: '100vh',
-					background: 'rgba(28, 28, 30, 0.5)',
-					zIndex: 9999,
-				}}
-			>
-				<S.ContentWrapper
-					style={{ height: 'auto', padding: '40px 32px', borderRadius: '16px', backgroundColor: '#ffffff', textAlign: 'center' }}
-				>
-					{props.children}
-				</S.ContentWrapper>
-			</S.Container>
+			<>
+				<S.ModalBackdrop />
+				<S.Container>
+					<S.ContentWrapper
+						style={{
+							height: 'auto',
+							padding: '40px 32px',
+							borderRadius: '16px',
+							backgroundColor: '#ffffff',
+							textAlign: 'center',
+						}}
+					>
+						{props.children}
+					</S.ContentWrapper>
+				</S.Container>
+			</>
 		</ModalPortal>
 	);
 };

--- a/components/shared/ModalFrame/styled.ts
+++ b/components/shared/ModalFrame/styled.ts
@@ -8,13 +8,21 @@ export const Container = styled.div`
 	justify-content: center;
 	min-width: 100vw;
 	min-height: 100vh;
+	z-index: 9999;
+`;
+
+export const ModalBackdrop = styled.div`
+	position: absolute;
+	inset: 0;
 	background-color: ${({ theme }) => theme.colors.gray_007};
 	opacity: 0.5;
-	z-index: 9999;
+	width: 100vw;
+	height: 100vh;
+	z-index: 5000;
 `;
 
 export const ContentWrapper = styled.div`
 	padding: 40px 32px;
 	border-radius: 16px;
-	background: ${({ theme }) => theme.colors.white};
+	background-color: ${({ theme }) => theme.colors.white};
 `;

--- a/store/actions/index.ts
+++ b/store/actions/index.ts
@@ -1,1 +1,2 @@
 export * as storeRegistrationStore from './storeRegistrationStore';
+export * as modalStore from './modalStore';

--- a/store/actions/modalStore.ts
+++ b/store/actions/modalStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+export const MODAL_KEY = {
+	OFF: 'OFF',
+	ON_LEAVE_MEMBER_CONFIRM_MODAL: 'ON_LEAVE_MEMBER_CONFIRM_MODAL',
+	ON_LEAVE_MEMBER_SUCCESS_MODAL: 'ON_LEAVE_MEMBER_SUCCESS_MODAL',
+	ON_STORE_EDIT_COMPLETION_CONFIRM_MODAL: 'ON_STORE_EDIT_COMPLETION_CONFIRM_MODAL',
+	ON_STORE_EDIT_SUCCESS_MODAL: 'ON_STORE_EDIT_SUCCESS_MODAL',
+	ON_STORE_PRODUCT_EDIT_EXIT_CONFIRM_MODAL: 'ON_STORE_PRODUCT_EDIT_EXIT_CONFIRM_MODAL',
+	ON_STORE_PRODUCT_EDIT_SUCCESS_MODAL: 'ON_STORE_PRODUCT_EDIT_SUCCESS_MODAL',
+	ON_STORE_PRODUCT_REQUIRED_WARNING_MODAL: 'ON_STORE_PRODUCT_REQUIRED_WARNING_MODAL',
+	ON_STORE_REGISTRATION_CANCEL_CONFIRM_MODAL: 'ON_STORE_REGISTRATION_CANCEL_CONFIRM_MODAL',
+	ON_STORE_REGISTRATION_CANCEL_SUCCESS_MODAL: 'ON_STORE_REGISTRATION_CANCEL_SUCCESS_MODAL',
+	ON_STORE_REGISTRATION_CONFIRM_MODAL: 'ON_STORE_REGISTRATION_CONFIRM_MODAL',
+	ON_STORE_REGISTRATION_EXIT_CONFIRM_MODAL: 'ON_STORE_REGISTRATION_EXIT_CONFIRM_MODAL',
+	ON_STORE_REGISTRATION_STEP_CHANGE_CONFIRM_MODAL: 'ON_STORE_REGISTRATION_STEP_CHANGE_CONFIRM_MODAL',
+} as const;
+
+export type ModalStore = {
+	modalKey: string;
+	changeModalKey: (changedModalKey: string) => void;
+};
+
+export type InitialState = { modalKey: string };
+export type setModal = { changeModal: (changedModalKey: string) => void };
+
+export const modalStore = (set) => ({
+	modalKey: MODAL_KEY.OFF,
+	changeModalKey: (changedModalKey: string) => set(() => ({ modalKey: changedModalKey })),
+});
+
+const useModalStore = create<ModalStore>()(process.env.NODE_ENV === 'production' ? modalStore : devtools(modalStore));
+
+export default useModalStore;


### PR DESCRIPTION
## 📎 Related Issues

- #39 

<br />

## 📋 작업 내용

- 매장 삭제 버튼 클릭 시 Modal 플로우 연결
- 회원 탈퇴하기 버튼 클릭 시 Modal 플로우 연결
- ModalFrame 스타일 수정 (Backdrop UI 추가)

<br />

## 🔎 PR Point

- Modal on / off Trigger 를 관리하는 Zustand Store 를 생성

<br />

## 👀 스크린샷 / GIF / 링크

### 입점 매장 삭제 Modal 클릭 플로우

![pump_mypage_delete_store_modal](https://user-images.githubusercontent.com/50790145/215257386-1fe7eaa7-c5a6-4fb6-b4eb-c1e043021417.gif)

### 회원 탈퇴 Modal 클릭 플로우

![pump_mypage_leave_member_modal](https://user-images.githubusercontent.com/50790145/215257392-1d1be5eb-00c7-4476-82e6-d8218643da5b.gif)

<br />

## ➕ 추가적인 태스크

- Modal Action 에 대한 실제 API 플로우 연동 

<br />

## 📚 Reference

### 기본 개념 & 사용법

- [Zustand 기본 컨셉 및 사용법 정리 블로그 포스팅](https://velog.io/@jyooj08/Zustand-%ED%95%9C-%EB%B0%A9%EC%97%90-%EC%A0%95%EB%A6%AC)
- [Zustand - TypeScript 공식문서 번역 블로그 포스팅](https://itchallenger.tistory.com/606)
- [Zustand - React-Query 를 같이 사용하는 방법 블로그 포스팅](https://itchallenger.tistory.com/814)

### Devtools 적용

- [How to use zustand devtools with typescript?](https://stackoverflow.com/questions/74223036/how-to-use-zustand-devtools-with-typescript)
- [How to use devtools middleware with typescript](https://github.com/pmndrs/zustand/discussions/976)

### Zutand Store TypeScript TypeError

- [Typescript issues with set function when creating store](https://github.com/pmndrs/zustand/issues/656)

### 기타

- [Pmndrs.docs - Zustand TypeScript Guide](https://docs.pmnd.rs/zustand/guides/typescript)

<br />

## ✅ PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다. (개인 작업시에만 확인)
- [x] Critical 한 Error 또는 Warning 이 존재하지 않습니다. 
- [x] 브라우저에 console 이 존재하지 않습니다.
