### PR TITLE
[#42] 운영시간 form 구현

### DIFF
--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -38,6 +38,15 @@ interface IBusinessLicenseStatusResponse {
 }
 
 const Step2 = () => {
+	const businessHourDays = [
+		{ id: 2, day: '월' },
+		{ id: 3, day: '화' },
+		{ id: 4, day: '수' },
+		{ id: 5, day: '목' },
+		{ id: 6, day: '금' },
+		{ id: 7, day: '토' },
+		{ id: 8, day: '일' },
+	];
 	const [storePostcodeInputs, setStorePostcodeInputs] = useState({
 		zonecode: '', // 우편번호
 		address: '', // 기본 주소
@@ -311,7 +320,7 @@ const Step2 = () => {
 						</label>
 					</StyledLayout.FlexBox>
 				</StyledLayout.FlexBox>
-				{selectedBusinessHourBtn === 'weekDaysWeekEnd' && (
+				{selectedBusinessHourBtn === 'weekDaysWeekEnd' ? (
 					<StyledLayout.FlexBox flexDirection="column" gap="12px">
 						<StyledLayout.FlexBox>
 							<StyledLayout.FlexBox flexDirection="column" gap="6px">
@@ -340,6 +349,25 @@ const Step2 = () => {
 							/>
 							<DayOffBtn dayOff={dayOffStatus} onClick={handleTimePickerInput} style={{ marginLeft: '6px' }} />
 						</StyledLayout.FlexBox>
+					</StyledLayout.FlexBox>
+				) : (
+					<StyledLayout.FlexBox flexDirection="column" gap="12px">
+						{businessHourDays.map(({ id, day }) => {
+							return (
+								<StyledLayout.FlexBox key={id}>
+									<StyledLayout.FlexBox flexDirection="column" gap="6px">
+										<Typography variant="h3" aggressive="button_001" color="gray_007" margin="0 20px 0 0">
+											{day}
+										</Typography>
+									</StyledLayout.FlexBox>
+									<TimePicker
+										dayOffRef={(el: RefObject<HTMLButtonElement>) => (dayOffRef.current[id] = el)}
+										disabled={dayOffStatus}
+									/>
+									<DayOffBtn dayOff={dayOffStatus} onClick={handleTimePickerInput} style={{ marginLeft: '6px' }} />
+								</StyledLayout.FlexBox>
+							);
+						})}
 					</StyledLayout.FlexBox>
 				)}
 			</StyledLayout.TextFieldSection>

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { RefObject, useState, useRef, FormEvent, ChangeEvent } from 'react';
+import { RefObject, useState, useRef, FormEvent, ChangeEvent, useEffect } from 'react';
 import Image from 'next/image';
 import axios from 'axios';
 import { LargeBtn, StyledLayout, Typography } from 'components/shared';
@@ -44,7 +44,7 @@ const Step2 = () => {
 		addressDetail: '', // 상세 주소
 	});
 	const businessLicenseInputRef = useRef() as RefObject<HTMLInputElement>;
-	const dayOffRef = useRef() as RefObject<HTMLButtonElement>;
+	const dayOffRef = useRef<null[] | Array<RefObject<HTMLButtonElement>>>([]);
 	const [dayOffStatus, setDayOffStatus] = useState<boolean>(false);
 	const [businessLicenseStatus, setBusinessLicenseStatus] = useState<'normal' | 'success' | 'error' | 'notClicked'>('normal');
 	const [selectedStoreImageBtn, setSelectedStoreImageBtn] = useState('defaultImage');
@@ -132,6 +132,9 @@ const Step2 = () => {
 		}
 		changeNormal(6);
 	};
+	useEffect(() => {
+		console.log(dayOffRef);
+	}, [dayOffRef.current[0]]);
 	return (
 		<form onSubmit={handleOnSubmit}>
 			<StyledLayout.TextFieldSection>
@@ -308,8 +311,37 @@ const Step2 = () => {
 						</label>
 					</StyledLayout.FlexBox>
 				</StyledLayout.FlexBox>
-				<TimePicker dayOffRef={dayOffRef} name="monday" disabled={dayOffStatus} />
-				<DayOffBtn dayOff={dayOffStatus} onClick={handleTimePickerInput} />
+				{selectedBusinessHourBtn === 'weekDaysWeekEnd' && (
+					<StyledLayout.FlexBox flexDirection="column" gap="12px">
+						<StyledLayout.FlexBox>
+							<StyledLayout.FlexBox flexDirection="column" gap="6px">
+								<Typography variant="h3" aggressive="button_001" color="gray_007">
+									평일
+								</Typography>
+								<Typography variant="h4" aggressive="body_oneline_004" color="gray_005" margin="0 20px 0 0">
+									(월~금)
+								</Typography>
+							</StyledLayout.FlexBox>
+							<TimePicker dayOffRef={(el: RefObject<HTMLButtonElement>) => (dayOffRef.current[0] = el)} name="weekDays" />
+						</StyledLayout.FlexBox>
+						<StyledLayout.FlexBox>
+							<StyledLayout.FlexBox flexDirection="column" gap="6px">
+								<Typography variant="h3" aggressive="button_001" color="gray_007">
+									주말
+								</Typography>
+								<Typography variant="h4" aggressive="body_oneline_004" color="gray_005" margin="0 20px 0 0">
+									(토~일)
+								</Typography>
+							</StyledLayout.FlexBox>
+							<TimePicker
+								dayOffRef={(el: RefObject<HTMLButtonElement>) => (dayOffRef.current[1] = el)}
+								name="WeekEnd"
+								disabled={dayOffStatus}
+							/>
+							<DayOffBtn dayOff={dayOffStatus} onClick={handleTimePickerInput} style={{ marginLeft: '6px' }} />
+						</StyledLayout.FlexBox>
+					</StyledLayout.FlexBox>
+				)}
 			</StyledLayout.TextFieldSection>
 			<StyledLayout.TextFieldSection>
 				<label htmlFor="dayOff">

--- a/app/registration/step2/page.tsx
+++ b/app/registration/step2/page.tsx
@@ -121,14 +121,6 @@ const Step2 = () => {
 			// 활성사업자
 			setBusinessLicenseStatus('success');
 		}
-
-		if (b_stt_cd === '02') {
-			// 휴업자
-		}
-
-		if (b_stt_cd === '03') {
-			// 폐업자
-		}
 		businessLicenseInputRef.current.blur();
 	};
 	const handleUploadToClient = async (e: ChangeEvent<HTMLInputElement>) => {

--- a/components/feature/Button/DayOffBtn/index.tsx
+++ b/components/feature/Button/DayOffBtn/index.tsx
@@ -6,7 +6,7 @@ type Props = {
 
 const DayOffBtn = ({ dayOff, ...props }: Props) => {
 	return (
-		<DayOffBtnContainer type="button" dayOff={dayOff} onClick={props.onClick}>
+		<DayOffBtnContainer type="button" dayOff={dayOff} style={props.style} onClick={props.onClick}>
 			휴무일로 지정
 		</DayOffBtnContainer>
 	);

--- a/components/feature/TimePicker/index.tsx
+++ b/components/feature/TimePicker/index.tsx
@@ -2,10 +2,9 @@ import { ChangeEvent, FocusEvent, RefObject, useEffect, useState } from 'react';
 import { TimePickerContainer, TimeInput, CenterSpan } from './styled';
 
 type Props = {
-	name: string;
-	dayOffRef: RefObject<HTMLButtonElement>;
+	dayOffRef: (el: RefObject<HTMLButtonElement>) => RefObject<HTMLButtonElement>;
 } & React.ComponentProps<'button'>;
-const TimePicker = ({ name, dayOffRef, ...props }: Props) => {
+const TimePicker = ({ dayOffRef, ...props }: Props) => {
 	const [timePickerValue, setTimePickerValue] = useState('');
 	const [timeValues, setTimeValues] = useState({
 		startHour: '10',
@@ -32,7 +31,14 @@ const TimePicker = ({ name, dayOffRef, ...props }: Props) => {
 		setTimePickerValue(`${timeValues.startHour}:${timeValues.startMinutes}~${timeValues.endHour}:${timeValues.endMinutes}`);
 	}, [timeValues]);
 	return (
-		<TimePickerContainer name={name} value={timePickerValue} type="button" ref={dayOffRef} disabled={props.disabled}>
+		<TimePickerContainer
+			name={props.name}
+			id={props.id}
+			value={props.disabled === true ? 'null' : timePickerValue}
+			type="button"
+			ref={dayOffRef}
+			disabled={props.disabled ?? false}
+		>
 			<TimeInput
 				onBlur={handleOnBlur}
 				value={timeValues.startHour}
@@ -40,7 +46,7 @@ const TimePicker = ({ name, dayOffRef, ...props }: Props) => {
 				type="text"
 				maxLength={2}
 				onChange={handleTimePickerValue}
-				disabled={props.disabled}
+				disabled={props.disabled ?? false}
 			/>
 			<span>:</span>
 			<TimeInput
@@ -50,7 +56,7 @@ const TimePicker = ({ name, dayOffRef, ...props }: Props) => {
 				type="text"
 				maxLength={2}
 				onChange={handleTimePickerValue}
-				disabled={props.disabled}
+				disabled={props.disabled ?? false}
 			/>
 			<CenterSpan>~</CenterSpan>
 			<TimeInput
@@ -60,7 +66,7 @@ const TimePicker = ({ name, dayOffRef, ...props }: Props) => {
 				type="text"
 				maxLength={2}
 				onChange={handleTimePickerValue}
-				disabled={props.disabled}
+				disabled={props.disabled ?? false}
 			/>
 			<span>:</span>
 			<TimeInput
@@ -70,7 +76,7 @@ const TimePicker = ({ name, dayOffRef, ...props }: Props) => {
 				type="text"
 				maxLength={2}
 				onChange={handleTimePickerValue}
-				disabled={props.disabled}
+				disabled={props.disabled ?? false}
 			/>
 		</TimePickerContainer>
 	);

--- a/components/feature/TimePicker/index.tsx
+++ b/components/feature/TimePicker/index.tsx
@@ -1,17 +1,25 @@
-import { ChangeEvent, FocusEvent, RefObject, useEffect, useState } from 'react';
+import { ChangeEvent, FocusEvent, useEffect, useState } from 'react';
 import { TimePickerContainer, TimeInput, CenterSpan } from './styled';
 
 type Props = {
-	dayOffRef: (el: RefObject<HTMLButtonElement>) => RefObject<HTMLButtonElement>;
-} & React.ComponentProps<'button'>;
-const TimePicker = ({ dayOffRef, ...props }: Props) => {
+	value?: {
+		startHour: string;
+		startMinutes: string;
+		endHour: string;
+		endMinutes: string;
+	};
+	dayOffRef: (el: HTMLButtonElement) => void;
+} & Omit<React.ComponentProps<'button'>, 'value'>;
+const TimePicker = ({ value, dayOffRef, ...props }: Props) => {
 	const [timePickerValue, setTimePickerValue] = useState('');
-	const [timeValues, setTimeValues] = useState({
-		startHour: '10',
-		startMinutes: '00',
-		endHour: '22',
-		endMinutes: '00',
-	});
+	const [timeValues, setTimeValues] = useState(
+		value ?? {
+			startHour: '10',
+			startMinutes: '00',
+			endHour: '22',
+			endMinutes: '00',
+		},
+	);
 	const handleTimePickerValue = (e: ChangeEvent<HTMLInputElement>) => {
 		const { value, name } = e.target;
 
@@ -28,13 +36,17 @@ const TimePicker = ({ dayOffRef, ...props }: Props) => {
 		});
 	};
 	useEffect(() => {
-		setTimePickerValue(`${timeValues.startHour}:${timeValues.startMinutes}~${timeValues.endHour}:${timeValues.endMinutes}`);
-	}, [timeValues]);
+		if (props.disabled) {
+			setTimePickerValue('null');
+			return;
+		} else
+			setTimePickerValue(`${timeValues.startHour}:${timeValues.startMinutes}~${timeValues.endHour}:${timeValues.endMinutes}`);
+	}, [timeValues, props.disabled]);
 	return (
 		<TimePickerContainer
 			name={props.name}
 			id={props.id}
-			value={props.disabled === true ? 'null' : timePickerValue}
+			value={timePickerValue}
 			type="button"
 			ref={dayOffRef}
 			disabled={props.disabled ?? false}

--- a/core/storeRegistrationService.ts
+++ b/core/storeRegistrationService.ts
@@ -1,3 +1,5 @@
+import { MutableRefObject, RefObject } from 'react';
+
 export const extractBusinessLicenseExceptHyhpen = (businessLicense: string) => {
 	return businessLicense
 		.split('')
@@ -13,4 +15,38 @@ export const checkEmptyInputError = (inputArr: RadioNodeList, changeError: (id: 
 		}
 	}
 	return emptyInput;
+};
+export const businessHourDays = [
+	{ id: 2, day: '월' },
+	{ id: 3, day: '화' },
+	{ id: 4, day: '수' },
+	{ id: 5, day: '목' },
+	{ id: 6, day: '금' },
+	{ id: 7, day: '토' },
+	{ id: 8, day: '일' },
+];
+export const makeBusinessHourData = (
+	refArr: MutableRefObject<Array<RefObject<HTMLButtonElement>> | null[] | HTMLButtonElement[]>,
+	selectedBusinessHourBtn: string,
+) => {
+	const businessHourArr = [];
+	if (selectedBusinessHourBtn === 'weekDaysWeekEnd') {
+		for (let i = 0; i < 5; i++) {
+			businessHourArr.push({ day: businessHourDays[i].day, time: (refArr.current[0] as HTMLButtonElement).value });
+		}
+		for (let i = 5; i < 7; i++) {
+			businessHourArr.push({ day: businessHourDays[i].day, time: (refArr.current[1] as HTMLButtonElement).value });
+		}
+	} else {
+		for (let i = 0; i < 7; i++) {
+			businessHourArr.push({
+				day: businessHourDays[i].day,
+				time: (refArr.current[businessHourDays[i].id] as HTMLButtonElement).value,
+			});
+		}
+	}
+	return JSON.stringify(businessHourArr)
+		.split('')
+		.filter((c) => c !== '"')
+		.join('');
 };


### PR DESCRIPTION
## 📎 Related Issues

- close #42

<br />

## 📋 작업 내용

- [x] 운영시간 form 만들기
- [x]  각각의 운영시간 선택했을 때 기능하도록
- [x] 운영시간 value 가져오는 로직 짜기
<br />

## 🔎 PR Point
## 운영시간 form 완성

- 운영시간 form 을 완성했습니다
- 평일 / 주말 ,요일별 각 라디오 버튼 누를 때 적절한 UI를 띄웁니다
- `휴무일로 지정` 버튼을 누르면 버튼 바로 좌측의 timepicker 만 비활성화 됩니다
- timepicker의 props를 수정하여, value를 넣을 수 있도록 했습니다(나중에 정보 수정단에서 사용)
    
    ```tsx
    <TimePicker
    								dayOffRef={(el) => (dayOffRef.current[1] = el)}
    								name="WeekEnd"
    								disabled={dayOffStatus[0]}
    								value={{
    									startHour: '11',
    									startMinutes: '11',
    									endHour: '11',
    									endMinutes: '11',
    								}}
    							/>
    ```
    
- submit 버튼이 작동할 때, 데이터를 stringfy 합니다
    
    ```tsx
    // 예시이며, 해당 형태가 맞는지 서버팀에 한 번 더 체킹 필요
    [{day:월,time:10:00~22:00},{day:화,time:10:00~22:00},{day:수,time:10:00~22:00},{day:목,time:10:00~22:00},{day:금,time:10:00~22:00},{day:토,time:19:11~11:41},{day:일,time:19:11~11:41}]
    ```
    
- useRef를 배열로 선언하여, 각각의 day에 뿌려주었습니다. 배열의 형태로 사용하기 위해 아래와 같은 형태가 되었습니다
    
    ```tsx
    // timepicker 컴포넌트에 props 넘겨줄때
    dayOffRef={(el) => (dayOffRef.current[1] = el)}
    ```
    
- 비즈니스 로직 분리는 추후 api 연결 전 리팩토링 해보도록 하겠습니다

<br />

## 😡 Trouble Shooting

- (이 작업을 하던 중에 발생했던 것)

<br />

## 👀 스크린샷 / GIF / 링크
![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/80065381/216167168-9224b147-8de8-49e3-a5a9-e65f72ea2d1d.gif)



<br />

<br />

## 📚 Reference

https://reactjs-kr.firebaseapp.com/docs/refs-and-the-dom.html
https://velog.io/@uknowsj/useRef-%EB%B0%B0%EC%97%B4%EB%A1%9C-%EC%B4%88%EA%B8%B0%ED%99%94

<br />

## ✅ PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다. (개인 작업시에만 확인)
- [x] Critical 한 Error 또는 Warning 이 존재하지 않습니다. 
- [x] 브라우저에 console 이 존재하지 않습니다.
