### PR TITLE
[#56] 배포 이전 부수 작업

### DIFF
--- a/components/feature/MyPageSection/MyPageSectionRegisteredStore/index.tsx
+++ b/components/feature/MyPageSection/MyPageSectionRegisteredStore/index.tsx
@@ -7,9 +7,10 @@ import useModalStore, { MODAL_KEY } from 'store/actions/modalStore';
 import { Store } from 'hooks/api/store/useGetStore';
 import { convertToHyphenDateFromUTC } from 'utils/date';
 import { MyPageStoreDefualtImg } from 'public/static/images';
+import Link from 'next/link';
 
 const MyPageSectionRegisteredStore = ({ store }: { store: Store }) => {
-	const { name, address, callNumber, isReady, imgStore, modifiedAt } = store;
+	const { id, name, address, callNumber, isReady, imgStore, modifiedAt } = store;
 
 	const { changeModalKey } = useModalStore();
 
@@ -49,16 +50,37 @@ const MyPageSectionRegisteredStore = ({ store }: { store: Store }) => {
 				<StyledLayout.FlexBox flexDirection={'column'} justifyContent={'flex-start'} gap={'8px'}>
 					{isReady ? (
 						<>
-							<MyPageActionBtn buttonTheme="black" type="button" onClick={() => console.info('판매제품 수정 GO')}>
-								판매제품 수정
+							<MyPageActionBtn buttonTheme="black" type="button">
+								<Link
+									href={{
+										pathname: `/registration/step3`,
+										query: { id, isReady },
+									}}
+								>
+									판매제품 수정
+								</Link>
 							</MyPageActionBtn>
-							<MyPageActionBtn buttonTheme="white" type="button" onClick={() => console.info('가게정보 수정 GO')}>
-								가게정보 수정
+							<MyPageActionBtn buttonTheme="white" type="button">
+								<Link
+									href={{
+										pathname: `/registration/step2`,
+										query: { id, isReady },
+									}}
+								>
+									가게정보 수정
+								</Link>
 							</MyPageActionBtn>
 						</>
 					) : (
-						<MyPageActionBtn buttonTheme="black" onClick={() => console.info('수정하기 GO')}>
-							수정하기
+						<MyPageActionBtn buttonTheme="black">
+							<Link
+								href={{
+									pathname: `/registration/step3`,
+									query: { id, isReady },
+								}}
+							>
+								수정하기
+							</Link>
 						</MyPageActionBtn>
 					)}
 				</StyledLayout.FlexBox>


### PR DESCRIPTION
## 📎 Related Issues

- #56 

<br />

## 📋 작업 내용

- 매장정보 수정, & 판매제품 수정 버튼 클릭 시 라우팅(입점한 매장이 O 가정), 수정하기 버튼 클릭 시 라우팅(입점한 매점이 X 경우)

<br />

## 🔎 PR Point

- 라우팅을 해주는 페이지(ex. 마이페이지)에서는 Link 태그에 pathname 과 query 를 이용해서 필요한 query 를 전달
- 라우팅된 페이지(ex. 입점신청 페이지)에서는 `useSearchParams` (in. `next/navigation`) hook 을 사용해 필요한 타겟 param 이 있는지 get 할 것

<br />

## 👀 캡쳐

<img width="470" alt="image" src="https://user-images.githubusercontent.com/50790145/218298950-f3a4db6b-3798-40c1-b246-ebd0663533aa.png">

<br />

## 📚 Reference

- [Next.js 13 ver 기준 - query params 를 다른 페이지 라우팅시 넘겨주고 싶을 때](https://stackoverflow.com/questions/74580728/get-url-params-next-js-13)

<br />

## ✅ PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다. (개인 작업시에만 확인)
- [x] Critical 한 Error 또는 Warning 이 존재하지 않습니다. 
- [x] 브라우저에 console 이 존재하지 않습니다.
