### PR TITLE
[#59] 배포 전 부수 작업 - Protected Route 고려

### DIFF
--- a/app/registration/step1/page.tsx
+++ b/app/registration/step1/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TextField } from 'components/feature';
-import { LargeBtn, StyledLayout, Typography } from 'components/shared';
+import { LargeBtn, StyledLayout, Typography, PrivateRoute } from 'components/shared';
 import { checkEmptyInputError } from 'core/storeRegistrationService';
 import { FormEvent } from 'react';
 import { useStep1Store } from 'store/actions/storeRegistrationStore';
@@ -74,4 +74,4 @@ const Step1 = () => {
 	);
 };
 
-export default Step1;
+export default PrivateRoute(Step1);

--- a/components/shared/PrivateRoute/index.tsx
+++ b/components/shared/PrivateRoute/index.tsx
@@ -1,0 +1,29 @@
+import { useGetUserSession, UserSession } from 'hooks/api/auth/useUserSession';
+import { NextPage } from 'next';
+import { useRouter } from 'next/navigation';
+import React, { useEffect } from 'react';
+import useUserSessionStore from 'store/actions/userSessionStore';
+import { getUserTokenFromLocalStorage } from 'utils/storage';
+
+const PrivateRoute = (Component: NextPage | React.FC) => {
+	const Auth = () => {
+		const router = useRouter();
+		const token = getUserTokenFromLocalStorage();
+		const { data } = useGetUserSession();
+		const { setUserSession } = useUserSessionStore();
+
+		useEffect(() => {
+			if (!token) {
+				router.replace('/signin');
+			} else {
+				setUserSession(data as UserSession);
+			}
+		}, []);
+
+		return token ? <Component /> : null;
+	};
+
+	return Auth;
+};
+
+export default PrivateRoute;

--- a/components/shared/index.ts
+++ b/components/shared/index.ts
@@ -8,6 +8,7 @@ export { default as ModalFrame } from 'components/shared/ModalFrame';
 export { default as Checkbox } from 'components/shared/Checkbox';
 export { default as Label } from 'components/shared/Label';
 export { default as LoadingCircleLottie } from 'components/shared/Lottie/LoadingCircleLottie';
+export { default as PrivateRoute } from './PrivateRoute';
 
 // Only Styled Components
 export * as StyledLayout from 'components/shared/styled/layout';


### PR DESCRIPTION
## 📎 Related Issues

- #59 


<br />

## 📋 작업 내용

- 랜딩페이지 - 입점신청 버튼 로그인 유무에 따른 라우팅 분기처리


<br />

## 🔎 PR Point

- `PrivateRoute` 라는 컴포넌트를 생성
- 파라미터로 NextPage 또는 React.FC 를 props 로 받음
- storage 에 토큰 유무에 따라 로그인 유무에 따라 signin 페이지로 라우팅할지, 원래 라우팅되어야하는지 분기처리함


<br />


## 📚 Reference

- [Protectec Route in. Next.js 블로그 포스팅](https://velog.io/@henrynoowah/Next.js-Private-Route)


<br />

## ✅ PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다. (개인 작업시에만 확인)
- [x] Critical 한 Error 또는 Warning 이 존재하지 않습니다. 
- [x] 브라우저에 console 이 존재하지 않습니다.
