### PR TITLE
[#67] DEV 서버 배포 이후 - 버그 핸들링 1

### DIFF
--- a/app/mypage/member/page.tsx
+++ b/app/mypage/member/page.tsx
@@ -11,7 +11,7 @@ const MemberManagement = () => {
 	const router = useRouter();
 
 	const { modalKey, changeModalKey } = useModalStore();
-	const { setUserSession } = useUserSessionStore();
+	const { userSession, setUserSession } = useUserSessionStore();
 
 	const handleLeaveMemberConfirm = async () => {
 		try {
@@ -34,7 +34,7 @@ const MemberManagement = () => {
 				내 정보 관리
 			</Typography>
 
-			<MyPageSectionLeaveMember memberEmail={'forzero100@naver.com'} />
+			<MyPageSectionLeaveMember memberEmail={userSession.email} />
 
 			{modalKey === MODAL_KEY.ON_LEAVE_MEMBER_CONFIRM_MODAL && (
 				<LeaveMemberConfirmModal onCancel={() => changeModalKey(MODAL_KEY.OFF)} onConfirm={handleLeaveMemberConfirm} />

--- a/components/feature/MyPageSection/MyPageSectionLeaveMember/index.tsx
+++ b/components/feature/MyPageSection/MyPageSectionLeaveMember/index.tsx
@@ -3,17 +3,13 @@ import * as S from '../styled';
 import { Typography } from 'components/shared';
 import { MyPageActionBtn } from 'components/feature';
 
-type Props = {
-	memberEmail?: string | null;
-};
-
-const MyPageSectionLeaveMember = (props: Props) => {
+const MyPageSectionLeaveMember = ({ memberEmail }: { memberEmail?: string | null }) => {
 	const { changeModalKey } = useModalStore();
 
 	return (
 		<S.MyPageOneActionDescriptionWrapper>
 			<Typography aggressive="body_oneline_004" variant="p">
-				{props.memberEmail} 을 더 이상 사용하지 않으시나요?
+				{memberEmail} 을 더 이상 사용하지 않으시나요?
 			</Typography>
 			<MyPageActionBtn buttonTheme="lightgray" onClick={() => changeModalKey(MODAL_KEY.ON_LEAVE_MEMBER_CONFIRM_MODAL)}>
 				회원 탈퇴하기

--- a/components/feature/MyPageSideBar/index.tsx
+++ b/components/feature/MyPageSideBar/index.tsx
@@ -4,7 +4,6 @@ import * as S from './styled';
 import { StyledLayout, Typography } from 'components/shared';
 import { theme } from 'styles';
 import { EmblemKakaoIcon, EmblemNaverIcon } from 'public/static/icons';
-import { getSocialPlatformType } from 'core/signupService';
 import { usePathname } from 'next/navigation';
 import useUserSessionStore from 'store/actions/userSessionStore';
 
@@ -36,7 +35,8 @@ const MyPageSideBar = () => {
 						{userSession.email}
 					</Typography>
 
-					{getSocialPlatformType(userSession.email) === 'Naver' ? <EmblemNaverIcon /> : <EmblemKakaoIcon />}
+					{userSession.oauthType === 'NAVER' && <EmblemNaverIcon />}
+					{userSession.oauthType === 'KAKAO' && <EmblemKakaoIcon />}
 				</StyledLayout.FlexBox>
 			</StyledLayout.FlexBox>
 

--- a/components/shared/Header/index.tsx
+++ b/components/shared/Header/index.tsx
@@ -4,17 +4,23 @@ import { StyledLayout } from 'components/shared';
 import * as S from './styled';
 import { PumpLogo } from 'public/static/images';
 import { removeUserTokenInLocalStorage } from 'utils/storage';
-import useUserSessionStore, { initialState } from 'store/actions/userSessionStore';
-import { useRouter } from 'next/navigation';
+import useUserSessionStore from 'store/actions/userSessionStore';
 import { useGetUserSession } from 'hooks/api/auth/useUserSession';
 import Link from 'next/link';
 
 const Header = () => {
-	const { userSession } = useUserSessionStore();
+	const { data: userSessionFetch } = useGetUserSession();
+	const { userSession, setUserSession } = useUserSessionStore();
 
 	const handleLogoutClick = () => {
 		removeUserTokenInLocalStorage();
 	};
+
+	useEffect(() => {
+		if (userSessionFetch) {
+			setUserSession(userSessionFetch);
+		}
+	}, [userSessionFetch]);
 
 	return (
 		<S.Container>

--- a/core/signupService.ts
+++ b/core/signupService.ts
@@ -3,12 +3,3 @@ export const isValidatedSignupFormAgreement = (signupAgreementForm: { [key: stri
 
 	return Object.keys(copySignupAgreementForm).every((key) => copySignupAgreementForm[key]);
 };
-
-export const getSocialPlatformType = (email: string | null | undefined) => {
-	if (!email) return;
-
-	const splitedDomain = email.split('@')[1];
-	const socialPlatform = splitedDomain.split('.')[0];
-
-	return socialPlatform === 'naver' ? 'Naver' : 'Kakao';
-};

--- a/hooks/api/auth/useUserSession.ts
+++ b/hooks/api/auth/useUserSession.ts
@@ -40,9 +40,14 @@ export const getUserSession = async () => {
 	return response.data.data;
 };
 
+const GET_USER_SESSION_CACHE_TIME = 60 * 60 * 1000; // 60 minutes
+const GET_USER_SESSION_STALE_TIME = 59 * 60 * 1000; // 59 minutes
+
 export const useGetUserSession = () => {
 	return useQuery([getUserSessionQueryKey], async () => await getUserSession(), {
 		retry: 1,
+		cacheTime: GET_USER_SESSION_CACHE_TIME,
+		staleTime: GET_USER_SESSION_STALE_TIME,
 	});
 };
 


### PR DESCRIPTION
## 📎 Related Issues

- #67 

<br />

## 📋 작업 내용

- 마이페이지 - 회원관리 디폴트 메시지 텍스트(더미데이터 -> API 회원 이메일 데이터)
- 마이페이지 - 회원 프로필 소셜 엠블럼 렌더링 정보 반환 함수 수정 (Kakao 로그인이지만 Naver 엠블럼 나오는 현상)
- 유효한 userSessionStore 에 의존하는 컴포넌트 유저 API Call 부여 (Like. Header)
- UserSession GET API 에 Cache(60 min) & Stale Time(59 min) 을 적용함
  - 유저 정보 갱신은 현재 소셜 로그인을 통해 회원가입이 이뤄지므로 한번 진행되면 거의 변경될 상황이 없다고 판단
  - 그럼에도 불구하고 1시간 정도 틈을 줘서 Refetch 시도를 위해 Cache Time 설정
  - Stale Time 은 Cache Time 보다 작게 해야하므로 1분 정도 앞당겨 데이터 신선도를 죽임

<br />

## 🔎 PR Point

- 현재 서비스에서 `새로고침` 이후에도 LocalStorage 에 있는 `token` 이 존재(유효하고)한다면 UserSession 이 다시 UserSessionStore 에 저장되어야 이를 구독하고 있는 컴포넌트들에 데이터가 정상적으로 적용됨
- 어느 페이지에서나 보이는 Header 컴포넌트에서 useEffect 를 통해 리렌더링 될 때마다 GET User API Call 을 통해 받아온 유효한 UserSession 을 Zustand Store 에 저장
- 이 PR 이 올라가는 시점에서 useUserSessionStore 훅 (userSessionStore 를 get, set) 을 호출하고 의존하고 있는 컴포넌트 or 페이지는 `member 페이지` ,`회원가입 페이지`


<br />


## 참고

- [Why cacheTime in React Query should always be bigger than staleTime](https://www.codemzy.com/blog/react-query-cachetime-staletime)
- [React Query에서 staleTime과 cacheTime의 차이](https://velog.io/@yrnana/React-Query%EC%97%90%EC%84%9C-staleTime%EA%B3%BC-cacheTime%EC%9D%98-%EC%B0%A8%EC%9D%B4)

<br />

## ✅ PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다. (개인 작업시에만 확인)
- [x] Critical 한 Error 또는 Warning 이 존재하지 않습니다. 
- [x] 브라우저에 console 이 존재하지 않습니다.
