### PR TITLE
[#78] SEO(메타태그, 오픈그래프) 작업 1 & 기타 변경사항 반영

### DIFF
--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,8 +1,9 @@
 export default function Head() {
 	return (
 		<>
-			<title>Pump</title>
+			<title>Pump ㅣ 내 주변의 리필스테이션</title>
 			<meta content="width=device-width, initial-scale=1" name="viewport" />
+			<meta name="description" content="자연스럽게 리필 용기를 챙기는 날을 만드는 사람들" />
 			<link rel="shortcut icon" href="/favicon.ico" />
 		</>
 	);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,22 +1,22 @@
 'use client';
 
-import styled, { CSSProperties } from 'styled-components';
 import { StyledLayout, Typography } from 'components/shared';
-import Link from 'next/link';
+import { MotionShowBox } from 'components/shared/Motion';
+import { Divider } from 'components/shared/styled/layout';
 import Image from 'next/image';
-import { theme } from 'styles';
+import Link from 'next/link';
 import {
+	LandingAdvantage001Img,
+	LandingAdvantage002Img,
 	LandingAppImg,
 	LandingFeature001Img,
 	LandingFeature002Img,
 	LandingFeature003Img,
-	LandingAdvantage001Img,
-	LandingAdvantage002Img,
 } from 'public/static/images';
-import { Divider } from 'components/shared/styled/layout';
-import { MotionShowBox } from 'components/shared/Motion';
+import styled, { CSSProperties } from 'styled-components';
+import { theme } from 'styles';
 
-const SERVICE_INTRODUCE_PDF_LINK = 'https://drive.google.com/file/d/1ey4jGVBu7cLLtTeCRYaoy8mP_4B9GsTu/view?usp=share_link';
+const SERVICE_INTRODUCE_PDF_LINK = 'https://drive.google.com/file/d/1f40Y7fdPCTnH83JgiIMmdeFb_igRMUBP/view';
 
 const FEATURE_INTRO = [
 	{


### PR DESCRIPTION
## 📎 Related Issues

- #78 

<br />

## 📋 작업 내용

- 서비스 소개서 링크 변경
- (Next.js 13 ver 기준) SEO 컴포넌트 적용전 app root 단계에서 head.js 테스트 


<br />

## 😡 Trouble Shooting

### Next.js 13 ver 기준, 기존 `next-seo` 패키지를 이용한 방법 or 자체 개발 SEO 컴포넌트 적용이 안되는 현상

- Next.js 13 에서 app 디렉터리 내에서는 기본적으로 SSR 
- 자체 제작한 SEO 컴포넌트나 `next-seo` 패키지에서 제공하는 컴포넌트를 쓰나 Client-Side 에서 작동하는 코드
- 즉, js 가 로드되기 전까지는 컴포넌트에 제대로된 config 값이 적용이 안되는 등의 문제로 현재 적용하지 못함(차후 개별 PR 을 통해 해결할 것)

<br />

## 👀 스크린샷 / GIF / 링크

- [(아직 버전업이 안된 듯 하지만) Next.js 13.2 이후 버전부터는 더 이상 `head.js` 기능을 제공하지 않고 deprecated 될 예정이라고 함](https://beta.nextjs.org/docs/api-reference/metadata)
- 따라서 이후 버전에 맞는 SEO 를 적용하기 위한 적절한 방법은 찾든, `next-seo` 컴포넌트를 app 디렉터리 내에서 적용하는 방법을 찾아야함


<br />

## ✅ PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다. (개인 작업시에만 확인)
- [x] Critical 한 Error 또는 Warning 이 존재하지 않습니다. 
- [x] 브라우저에 console 이 존재하지 않습니다.
